### PR TITLE
GLM-5.3-Flash NVFP4: DFlash2 drafter + CUDA graphs, verified (prose 28.2/21.1/17.1, structured 51.4/41.5/35.7 tok/s, 327k ctx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,23 @@
 
 Serve [LibertAIDAI/GLM-5.3-Flash-NVFP4](https://huggingface.co/LibertAIDAI/GLM-5.3-Flash-NVFP4) across two NVIDIA DGX Spark (GB10) nodes at tensor-parallel 2.
 
-320B total / 18B active. Weight-only NVFP4 on routed experts (~181 GiB). Native context is 1,048,576. This recipe pins `--max-model-len` at 262144 with MTP-4.
+320B total / 18B active. Weight-only NVFP4 on routed experts (~181 GiB). Native context is 1,048,576. This recipe serves `--max-model-len` 327680 with the DFlash2 block-diffusion drafter (5 speculative tokens).
 
-Stock `vllm/vllm-openai:glm53-flash-arm64-cu130` loads on sm_121 and echoes the prompt. Build the local `glm53-sm121-v8` image first.
+Stock `vllm/vllm-openai:glm53-flash-arm64-cu130` loads on sm_121 and echoes the prompt. Build the local image chain through `glm53-sm121-v11` first.
 
 ## Measured on 2× DGX Spark (L.A.I.L lab)
 
-Decode only. Streamed greedy, thinking off, 200 completion tokens, 3-run median. `max-num-seqs=4`, MTP-4, fp8 KV pinned at 4.14 GiB.
+Decode only. Streamed greedy, thinking off, 200 completion tokens, 3-run median. `max-num-seqs=4`, fp8 KV pinned at 4.14 GiB, context 327680, DFlash2-5.
 
-| Concurrency | Decode tok/s (median per stream) | Aggregate tok/s | TTFT p50 |
-|---|---:|---:|---:|
-| 1 | 25.6 | 25.6 | 0.30 s |
-| 2 | 20.2 | 39.3 | 0.70 s |
-| 4 | 17.0 | 64.9 | 0.68 s |
+| Concurrency | Decode tok/s (median per stream) | Aggregate tok/s | TTFT p50 | vs MTP-4 |
+|---|---:|---:|---:|---:|
+| 1 | 26.8 | 26.8 | 0.32 s | +8% |
+| 2 | 21.6 | 41.3 | 0.35 s | +4% |
+| 4 | 17.0 | 67.6 | 0.65 s | +4% |
 
-KV pool at boot: 507,041 tokens (1.93× at 262144). First wave after restart paid JIT. Later waves sat at ~0.25–0.44 s TTFT. `python3 bench_decode.py` repeats this.
+MTP-4 on the same day measured 24.7 / 20.9 / 16.6 per stream (aggregate 24.7 / 39.6 / 65.1) at 262144 context. DFlash2-5 wins every concurrency and carries 25% more context.
+
+KV pool at boot: 400,497 tokens (1.22× at 327680). Acceptance length 2.9–3.0 of 6 slots on thinking-off chat prompts, 3.7+ on thinking-on math. A 318,123-token prompt (97% of the window) prefilled in 4m05s and answered a needle question exactly. First wave after restart pays Triton JIT per batch shape; warm waves sit at 0.23–0.65 s TTFT. `python3 bench_decode.py` repeats this and prints acceptance per concurrency block.
 
 ## Requirements
 
@@ -37,23 +39,33 @@ On both nodes, from this repo:
 ```bash
 docker build -f docker/Dockerfile.sm121-v8 -t glm53-sm121-v8 docker
 docker build -f docker/Dockerfile.sm121-v9 -t glm53-sm121-v9 docker
+docker build -f docker/Dockerfile.sm121-v10 -t glm53-sm121-v10 docker
+docker build -f docker/Dockerfile.sm121-v11 -t glm53-sm121-v11 docker
 ```
 
 The v8 Dockerfile starts from `vllm/vllm-openai:glm53-flash-arm64-cu130` and applies the sm_121 patches (NoPE FA2 backend, FlashInfer 0.6.18, NCCL 2.30.7, PDL off, indexer init, fp8 tile cap). `run.sh` refuses the stock tag.
 
-The v9 Dockerfile layers the DFlash2 backport (vLLM PR [#52816](https://github.com/vllm-project/vllm/pull/52816), missing from the image's vLLM snapshot) on top of v8. Only needed for `SPEC=dflash2`.
+The next three layers are all required for `SPEC=dflash2` (MTP works on v8):
+
+- v9 backports DFlash2 support, vLLM PR [#52816](https://github.com/vllm-project/vllm/pull/52816), missing from the image's vLLM snapshot.
+- v10 teaches the fork-only Glm5Next model to capture aux hidden states for the drafter (the mHC stream contraction follows the reference integration, sglang [#36708](https://github.com/sgl-project/sglang/pull/36708)).
+- v11 adds a dedicated draft KV group to the GLM5 bespoke KV layout so the draft's sliding-window layers share the pool.
 
 ## DFlash2 drafter
 
-[incoai/GLM-5.3-Flash-DFlash2](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2) is a 1B block-diffusion draft model that predicts a whole block per pass. Upstream reports it beating GLM's native MTP on acceptance length across every task they measured. Decoding is lossless.
+[incoai/GLM-5.3-Flash-DFlash2](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2) is a 1B block-diffusion draft model that predicts a whole block per pass. Upstream reports it beating GLM's native MTP on acceptance length across every task they measured. Decoding is lossless; our greedy outputs matched MTP's byte for byte.
+
+DFlash2 is the default drafter (`SPEC=dflash2`). Switch back with:
 
 ```bash
-IMAGE=glm53-sm121-v9 SPEC=dflash2 ./run.sh
+SPEC=mtp ./run.sh
 ```
 
-`run.sh` downloads the draft weights (~2.2 GiB, snapshot pinned) and passes `{"method":"dflash","model":<draft>,"num_speculative_tokens":7}` to both ranks. `bench_decode.py` reports the measured acceptance length per concurrency block.
+`run.sh` downloads the draft weights (~2.2 GiB, snapshot pinned) and passes `{"method":"dflash","model":<draft>,"num_speculative_tokens":5}` to both ranks.
 
-DFlash2 numbers on this cluster are not yet published here; the table above is MTP-4. The draft model's license is CC BY-NC-ND 4.0 (research and evaluation; commercial licensing via inco.ai). The base model and this recipe are unaffected when you stay on MTP.
+Why 5 and not the block's full 7: acceptance at draft positions 5–6 is under 15%, and each speculative slot costs a per-sequence KDA state copy (`num_spec+1` copies). At 7 slots the state of 4 sequences no longer fits the pool, so the 4th request queues for ~10 s at c=4; at 5 slots all four admit immediately and c=1 is faster too (26.8 vs 26.0). Going down to 4 slots truncates the block-diffusion draft too hard (acceptance 2.8, c=1 drops to 20.6).
+
+The draft model's license is CC BY-NC-ND 4.0 (research and evaluation; commercial licensing via inco.ai). The base model and this recipe are unaffected when you stay on MTP.
 
 ## Quick start
 
@@ -99,20 +111,20 @@ Stop both ranks from the head:
 
 | Setting | Value |
 |---|---|
-| Image | `glm53-sm121-v8` (local) |
+| Image | `glm53-sm121-v11` (local) |
 | Model | `LibertAIDAI/GLM-5.3-Flash-NVFP4` |
 | `--tensor-parallel-size` / `--nnodes` | 2 / 2 |
-| `--max-model-len` | 262144 |
+| `--max-model-len` | 327680 |
 | `--max-num-seqs` | 4 |
 | `--kv-cache-dtype` | `fp8_e4m3` |
 | `--kv-cache-memory` | `4445787956` (4.14 GiB) |
 | `--moe-backend` | `marlin` |
 | `--block-size` | 2304 |
-| Speculative | MTP-4 (`SPEC=dflash2` for DFlash2-7) |
+| Speculative | DFlash2-5 (`SPEC=mtp` for MTP-4) |
 | Reasoning / tools | `glm45` / `glm47` |
 | API | `http://<head>:8000/v1` |
 
-`--kv-cache-memory 4445787956` is the pin that kept MTP-4 alive on TP=2. Raising it or dropping it OOMs GB10 (`NV_ERR_NO_MEMORY`). Do not turn on InstantTensor. That loader killed TP=2 ranks here.
+`--kv-cache-memory 4445787956` stays the pin on TP=2. Dropping it OOMs GB10 (`NV_ERR_NO_MEMORY`). Raising it boots but backfires under UMA pressure: 5.0 GiB slowed decode ~20% at every concurrency, 5.14 GiB crashed under concurrent load. Do not turn on InstantTensor. That loader killed TP=2 ranks here.
 
 ## Environment
 
@@ -122,7 +134,7 @@ export WORKER_HOST=spark2
 export IFACE=enp1s0f1np1
 export HCA=rocep1s0f1
 export PORT=8000
-export MAX_MODEL_LEN=262144
+export MAX_MODEL_LEN=327680
 export MAX_NUM_SEQS=4
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,24 @@ On both nodes, from this repo:
 
 ```bash
 docker build -f docker/Dockerfile.sm121-v8 -t glm53-sm121-v8 docker
+docker build -f docker/Dockerfile.sm121-v9 -t glm53-sm121-v9 docker
 ```
 
-The Dockerfile starts from `vllm/vllm-openai:glm53-flash-arm64-cu130` and applies the sm_121 patches (NoPE FA2 backend, FlashInfer 0.6.18, NCCL 2.30.7, PDL off, indexer init, fp8 tile cap). `run.sh` refuses the stock tag.
+The v8 Dockerfile starts from `vllm/vllm-openai:glm53-flash-arm64-cu130` and applies the sm_121 patches (NoPE FA2 backend, FlashInfer 0.6.18, NCCL 2.30.7, PDL off, indexer init, fp8 tile cap). `run.sh` refuses the stock tag.
+
+The v9 Dockerfile layers the DFlash2 backport (vLLM PR [#52816](https://github.com/vllm-project/vllm/pull/52816), missing from the image's vLLM snapshot) on top of v8. Only needed for `SPEC=dflash2`.
+
+## DFlash2 drafter
+
+[incoai/GLM-5.3-Flash-DFlash2](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2) is a 1B block-diffusion draft model that predicts a whole block per pass. Upstream reports it beating GLM's native MTP on acceptance length across every task they measured. Decoding is lossless.
+
+```bash
+IMAGE=glm53-sm121-v9 SPEC=dflash2 ./run.sh
+```
+
+`run.sh` downloads the draft weights (~2.2 GiB, snapshot pinned) and passes `{"method":"dflash","model":<draft>,"num_speculative_tokens":7}` to both ranks. `bench_decode.py` reports the measured acceptance length per concurrency block.
+
+DFlash2 numbers on this cluster are not yet published here; the table above is MTP-4. The draft model's license is CC BY-NC-ND 4.0 (research and evaluation; commercial licensing via inco.ai). The base model and this recipe are unaffected when you stay on MTP.
 
 ## Quick start
 
@@ -93,7 +108,7 @@ Stop both ranks from the head:
 | `--kv-cache-memory` | `4445787956` (4.14 GiB) |
 | `--moe-backend` | `marlin` |
 | `--block-size` | 2304 |
-| Speculative | MTP-4 |
+| Speculative | MTP-4 (`SPEC=dflash2` for DFlash2-7) |
 | Reasoning / tools | `glm45` / `glm47` |
 | API | `http://<head>:8000/v1` |
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,22 @@ Stock `vllm/vllm-openai:glm53-flash-arm64-cu130` loads on sm_121 and echoes the 
 
 ## Measured on 2× DGX Spark (L.A.I.L lab)
 
-Decode only. Streamed greedy, thinking off, 200 completion tokens, 3-run median. `max-num-seqs=4`, fp8 KV pinned at 4.14 GiB, context 327680, DFlash2-5.
+Decode only. Streamed greedy, thinking off, 200 completion tokens, 3-run median. `max-num-seqs=4`, fp8 KV pinned at 4.14 GiB, context 327680, DFlash2-5, CUDA graphs. Prose is the low-acceptance regime (free text); structured (count 1→200, same protocol as the EXL3 recipe) is the high-acceptance regime.
 
-| Concurrency | Decode tok/s (median per stream) | Aggregate tok/s | TTFT p50 | vs MTP-4 |
-|---|---:|---:|---:|---:|
-| 1 | 26.8 | 26.8 | 0.32 s | +8% |
-| 2 | 21.6 | 41.3 | 0.35 s | +4% |
-| 4 | 17.0 | 67.6 | 0.65 s | +4% |
+| Phase | Concurrency | Decode tok/s (median per stream) | Aggregate tok/s | TTFT p50 | Eager same-day |
+|---|---|---:|---:|---:|---:|
+| prose | 1 | 28.2 | 28.2 | 0.24 s | 27.6 |
+| prose | 2 | 21.1 | 42.4 | 0.35 s | 20.0 |
+| prose | 4 | 17.1 | 66.9 | 0.63 s | 17.1 |
+| structured | 1 | 51.4 | 51.3 | 0.32 s | 49.6 |
+| structured | 2 | 41.5 | 81.8 | 0.35 s | 41.8 |
+| structured | 4 | 35.7 | 142.7 | 0.39 s | 35.0 |
 
-MTP-4 on the same day measured 24.7 / 20.9 / 16.6 per stream (aggregate 24.7 / 39.6 / 65.1) at 262144 context. DFlash2-5 wins every concurrency and carries 25% more context.
+CUDA graphs (previously avoided on sm_121 with `--enforce-eager`) resolved to FULL_AND_PIECEWISE with 4 uniform-decode graphs at the 6/12/18/24-token verify shapes, captured in 27 s at zero measurable memory cost, and held stable across two full benches: +2–5% at c=1/2, flat at c=4, acceptance unchanged. Greedy output stays lossless: a counting probe verified 100+ exact sequential tokens per stream at c=4 through graph replay, and the only text divergence vs eager was a near-tie token (0.125 nat margin) that flips run-to-run in either mode.
 
-KV pool at boot: 400,497 tokens (1.22× at 327680). Acceptance length 2.9–3.0 of 6 slots on thinking-off chat prompts, 3.7+ on thinking-on math. A 318,123-token prompt (97% of the window) prefilled in 4m05s and answered a needle question exactly. First wave after restart pays Triton JIT per batch shape; warm waves sit at 0.23–0.65 s TTFT. `python3 bench_decode.py` repeats this and prints acceptance per concurrency block.
+MTP-4 (eager, 262144 context) measured 24.7 / 20.9 / 16.6 per stream prose the same day the DFlash2-5 default landed. DFlash2-5 wins every concurrency and carries 25% more context.
+
+KV pool at boot: 400,497 tokens (1.22× at 327680), identical eager or graphs. Acceptance length on 6 slots: 2.9–3.0 prose (draft accept ~0.40), 5.4–5.5 structured (~0.89), 3.7+ on thinking-on math. A 318,123-token prompt (97% of the window) prefilled in 4m05s and answered a needle question exactly. First wave after restart pays Triton JIT per batch shape; warm waves sit at 0.23–0.65 s TTFT. `python3 bench_decode.py` repeats both phases and prints acceptance per concurrency block.
 
 ## Requirements
 
@@ -120,6 +125,7 @@ Stop both ranks from the head:
 | `--kv-cache-memory` | `4445787956` (4.14 GiB) |
 | `--moe-backend` | `marlin` |
 | `--block-size` | 2304 |
+| CUDA graphs | on, capture ladder 1/2/4 + 6/12/18/24 (`ENFORCE_EAGER=1` reverts to `--enforce-eager`) |
 | Speculative | DFlash2-5 (`SPEC=mtp` for MTP-4) |
 | Reasoning / tools | `glm45` / `glm47` |
 | API | `http://<head>:8000/v1` |
@@ -143,7 +149,8 @@ Pin `NCCL_IB_HCA`. GB10 exposes four HCAs and two of them are DOWN. Unpinned NCC
 ## Repeat the decode bench
 
 ```bash
-python3 bench_decode.py
+python3 bench_decode.py                    # both phases, c=1,2,4, 3 runs
+python3 bench_decode.py --phase structured # one phase only
 ```
 
 ## Logs

--- a/bench_decode.py
+++ b/bench_decode.py
@@ -85,7 +85,12 @@ def wave(url: str, model: str, max_tokens: int, concurrency: int) -> list[dict]:
     with ThreadPoolExecutor(max_workers=concurrency) as pool:
         futs = [pool.submit(stream_one, url, model, max_tokens) for _ in range(concurrency)]
         for fut in as_completed(futs):
-            out.append(fut.result())
+            try:
+                out.append(fut.result())
+            except Exception as exc:  # noqa: BLE001 - keep the wave's other streams
+                print(f"stream failed: {exc}", file=sys.stderr, flush=True)
+    if not out:
+        raise RuntimeError("every stream in the wave failed")
     wall = time.perf_counter() - t0
     decode_tokens = sum(max(r["completion_tokens"] - 1, 0) for r in out)
     # Shared wall clock after the first token of the slowest-to-start stream is messy.

--- a/bench_decode.py
+++ b/bench_decode.py
@@ -12,17 +12,26 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
-PROMPT = (
-    "Write a short paragraph about why sparse attention helps long-context "
-    "language models. Keep it around eighty words. No bullet points."
-)
+# Two decode regimes: prose is the low-acceptance regime (the drafter guesses
+# free text), structured is the high-acceptance regime (counting is nearly
+# deterministic, so most draft positions verify).
+PHASES = {
+    "prose": (
+        "Write a short paragraph about why sparse attention helps long-context "
+        "language models. Keep it around eighty words. No bullet points."
+    ),
+    "structured": (
+        "Count from 1 to 200. Output only the numbers, separated by commas, "
+        "with no other text."
+    ),
+}
 
 
-def stream_one(url: str, model: str, max_tokens: int) -> dict:
+def stream_one(url: str, model: str, prompt: str, max_tokens: int) -> dict:
     body = json.dumps(
         {
             "model": model,
-            "messages": [{"role": "user", "content": PROMPT}],
+            "messages": [{"role": "user", "content": prompt}],
             "max_tokens": max_tokens,
             "temperature": 0,
             "stream": True,
@@ -79,11 +88,13 @@ def stream_one(url: str, model: str, max_tokens: int) -> dict:
     }
 
 
-def wave(url: str, model: str, max_tokens: int, concurrency: int) -> list[dict]:
+def wave(
+    url: str, model: str, prompt: str, max_tokens: int, concurrency: int
+) -> tuple[list[dict], float, float]:
     t0 = time.perf_counter()
     out = []
     with ThreadPoolExecutor(max_workers=concurrency) as pool:
-        futs = [pool.submit(stream_one, url, model, max_tokens) for _ in range(concurrency)]
+        futs = [pool.submit(stream_one, url, model, prompt, max_tokens) for _ in range(concurrency)]
         for fut in as_completed(futs):
             try:
                 out.append(fut.result())
@@ -156,43 +167,46 @@ def main() -> int:
     p.add_argument("--max-tokens", type=int, default=200)
     p.add_argument("--runs", type=int, default=3)
     p.add_argument("--concurrency", type=int, nargs="+", default=[1, 2, 4])
+    p.add_argument("--phase", choices=[*PHASES, "both"], default="both")
     args = p.parse_args()
 
+    phases = list(PHASES) if args.phase == "both" else [args.phase]
     print(
         f"url={args.url} model={args.model} max_tokens={args.max_tokens} "
-        f"runs={args.runs} concurrency={args.concurrency}",
+        f"runs={args.runs} concurrency={args.concurrency} phases={phases}",
         flush=True,
     )
     metrics_url = args.url.split("/v1/", 1)[0] + "/metrics"
     summary = []
-    for c in args.concurrency:
-        per_stream = []
-        aggs = []
-        walls = []
-        counters_before = spec_counters(metrics_url)
-        for i in range(args.runs):
-            rows, wall, agg = wave(args.url, args.model, args.max_tokens, c)
-            per_stream.extend(rows)
-            aggs.append(agg)
-            walls.append(wall)
-            dec = ",".join(f"{r['decode_tok_s']:.2f}" for r in rows)
-            ttft = ",".join(f"{r['ttft_s']:.3f}" for r in rows)
-            print(
-                f"c={c} run={i+1} wall={wall:.2f}s agg={agg:.2f} tok/s "
-                f"per_stream=[{dec}] ttft=[{ttft}]",
-                flush=True,
+    for phase in phases:
+        prompt = PHASES[phase]
+        for c in args.concurrency:
+            per_stream = []
+            aggs = []
+            counters_before = spec_counters(metrics_url)
+            for i in range(args.runs):
+                rows, wall, agg = wave(args.url, args.model, prompt, args.max_tokens, c)
+                per_stream.extend(rows)
+                aggs.append(agg)
+                dec = ",".join(f"{r['decode_tok_s']:.2f}" for r in rows)
+                ttft = ",".join(f"{r['ttft_s']:.3f}" for r in rows)
+                print(
+                    f"phase={phase} c={c} run={i+1} wall={wall:.2f}s agg={agg:.2f} tok/s "
+                    f"per_stream=[{dec}] ttft=[{ttft}]",
+                    flush=True,
+                )
+            summary.append(
+                {
+                    "phase": phase,
+                    "concurrency": c,
+                    "median_decode_tok_s": median_key(per_stream, "decode_tok_s"),
+                    "median_ttft_s": median_key(per_stream, "ttft_s"),
+                    "median_agg_tok_s": statistics.median(aggs),
+                    "median_completion_tokens": median_key(per_stream, "completion_tokens"),
+                    "n": len(per_stream),
+                    **acceptance(counters_before, spec_counters(metrics_url)),
+                }
             )
-        summary.append(
-            {
-                "concurrency": c,
-                "median_decode_tok_s": median_key(per_stream, "decode_tok_s"),
-                "median_ttft_s": median_key(per_stream, "ttft_s"),
-                "median_agg_tok_s": statistics.median(aggs),
-                "median_completion_tokens": median_key(per_stream, "completion_tokens"),
-                "n": len(per_stream),
-                **acceptance(counters_before, spec_counters(metrics_url)),
-            }
-        )
     print("SUMMARY", json.dumps(summary, indent=2))
     return 0
 

--- a/bench_decode.py
+++ b/bench_decode.py
@@ -100,6 +100,50 @@ def median_key(rows: list[dict], key: str) -> float:
     return statistics.median(r[key] for r in rows)
 
 
+SPEC_COUNTERS = ("num_drafts", "num_draft_tokens", "num_accepted_tokens")
+
+
+def spec_counters(metrics_url: str) -> dict[str, float] | None:
+    """Sum vLLM's spec-decode counters across label sets. None when absent."""
+    try:
+        with urllib.request.urlopen(metrics_url, timeout=10) as resp:
+            text = resp.read().decode("utf-8", "replace")
+    except (OSError, urllib.error.URLError):
+        return None
+    out = dict.fromkeys(SPEC_COUNTERS, 0.0)
+    seen = False
+    for line in text.splitlines():
+        if line.startswith("#") or not line.startswith("vllm:spec_decode_"):
+            continue
+        name = line.split("{", 1)[0].split(" ", 1)[0]
+        for counter in SPEC_COUNTERS:
+            # prometheus_client >= 0.4 exposes Counters with a _total suffix;
+            # accept the bare name too. The two forms never coexist.
+            if name in (
+                f"vllm:spec_decode_{counter}_total",
+                f"vllm:spec_decode_{counter}",
+            ):
+                out[counter] += float(line.rsplit(" ", 1)[1])
+                seen = True
+    return out if seen else None
+
+
+def acceptance(before: dict[str, float] | None, after: dict[str, float] | None) -> dict:
+    if before is None or after is None:
+        return {}
+    drafts = after["num_drafts"] - before["num_drafts"]
+    draft_tokens = after["num_draft_tokens"] - before["num_draft_tokens"]
+    accepted = after["num_accepted_tokens"] - before["num_accepted_tokens"]
+    if drafts <= 0:
+        return {}
+    return {
+        # Emitted tokens per verification step: accepted draft tokens plus the
+        # verifier's own token, the "acceptance length" from spec-decode papers.
+        "acceptance_len": 1.0 + accepted / drafts,
+        "draft_acceptance_rate": (accepted / draft_tokens) if draft_tokens > 0 else 0.0,
+    }
+
+
 def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--url", default="http://127.0.0.1:8000/v1/chat/completions")
@@ -114,11 +158,13 @@ def main() -> int:
         f"runs={args.runs} concurrency={args.concurrency}",
         flush=True,
     )
+    metrics_url = args.url.split("/v1/", 1)[0] + "/metrics"
     summary = []
     for c in args.concurrency:
         per_stream = []
         aggs = []
         walls = []
+        counters_before = spec_counters(metrics_url)
         for i in range(args.runs):
             rows, wall, agg = wave(args.url, args.model, args.max_tokens, c)
             per_stream.extend(rows)
@@ -139,6 +185,7 @@ def main() -> int:
                 "median_agg_tok_s": statistics.median(aggs),
                 "median_completion_tokens": median_key(per_stream, "completion_tokens"),
                 "n": len(per_stream),
+                **acceptance(counters_before, spec_counters(metrics_url)),
             }
         )
     print("SUMMARY", json.dumps(summary, indent=2))

--- a/docker/Dockerfile.sm121-v10
+++ b/docker/Dockerfile.sm121-v10
@@ -1,0 +1,10 @@
+FROM glm53-sm121-v9
+
+# DFlash needs target hidden states via the EAGLE3 interface, which the
+# fork-only Glm5Next model does not implement. patch_v10 adds the capture with
+# the SGLang-verified mHC contraction semantics.
+COPY patch_v10_dflash_glm5.py /tmp/patch_v10_dflash_glm5.py
+RUN python3 /tmp/patch_v10_dflash_glm5.py \
+    && python3 -m compileall -q \
+        /usr/local/lib/python3.12/dist-packages/vllm/models/glm5next/nvidia/model.py \
+    && rm /tmp/patch_v10_dflash_glm5.py

--- a/docker/Dockerfile.sm121-v11
+++ b/docker/Dockerfile.sm121-v11
@@ -1,0 +1,10 @@
+FROM glm53-sm121-v10
+
+# The GLM-5-Next bespoke KV grouping rejects the DFlash draft's sliding-window
+# layers, falling back to a generic path that cannot unify the indexer page.
+# patch_v11 adds a dedicated draft KV group to the bespoke layout.
+COPY patch_v11_dflash_kv_groups.py /tmp/patch_v11_dflash_kv_groups.py
+RUN python3 /tmp/patch_v11_dflash_kv_groups.py \
+    && python3 -m compileall -q \
+        /usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_utils.py \
+    && rm /tmp/patch_v11_dflash_kv_groups.py

--- a/docker/Dockerfile.sm121-v9
+++ b/docker/Dockerfile.sm121-v9
@@ -1,0 +1,18 @@
+FROM glm53-sm121-v8
+
+# DFlash2 backport: vLLM PR #52816 (merged upstream as b389ac2946, missing from
+# this image's vLLM snapshot). dflash2_backport.diff is the PR's vllm/ changes
+# regenerated with exact context against this tree, so --fuzz=0 refuses drift.
+COPY dflash2_backport.diff /tmp/dflash2_backport.diff
+RUN cd /usr/local/lib/python3.12/dist-packages \
+    && patch -p1 --fuzz=0 --no-backup-if-mismatch < /tmp/dflash2_backport.diff \
+    && python3 -m compileall -q \
+        vllm/config/vllm.py \
+        vllm/model_executor/layers/logits_processor.py \
+        vllm/model_executor/models/qwen3_dflash.py \
+        vllm/model_executor/models/qwen3_dflash2.py \
+        vllm/model_executor/models/registry.py \
+        vllm/v1/worker/gpu/sample/gumbel.py \
+        vllm/v1/worker/gpu/spec_decode/ \
+    && grep -q '"DFlash2DraftModel"' vllm/model_executor/models/registry.py \
+    && rm /tmp/dflash2_backport.diff

--- a/docker/dflash2_backport.diff
+++ b/docker/dflash2_backport.diff
@@ -1,0 +1,900 @@
+diff --git a/vllm/config/vllm.py b/vllm/config/vllm.py
+index 019eb55..c5f3d47 100644
+--- a/vllm/config/vllm.py
++++ b/vllm/config/vllm.py
+@@ -651,6 +651,12 @@ class VllmConfig:
+         if self._dflash_needs_multi_kv_group():
+             return True
+ 
++        # The DFlash2 candidate selector exists only in the V2 speculator. On V1
++        # the same checkpoint drafts through DFlashProposer, which never calls
++        # it, so the draft degrades to DFlash1 silently. Force V2 as for dspark.
++        if self._is_dflash2_draft():
++            return True
++
+         if self.model_config is not None and self.model_config.is_diffusion:
+             return True
+ 
+@@ -674,6 +680,17 @@ class VllmConfig:
+ 
+         return True
+ 
++    def _is_dflash2_draft(self) -> bool:
++        """Whether the DFlash draft is a DFlash2 one, by the architecture the
++        speculator selects on (v1/worker/gpu/spec_decode/__init__.py)."""
++        spec = self.speculative_config
++        if spec is None or spec.method != "dflash":
++            return False
++        draft_config = getattr(spec, "draft_model_config", None)
++        if draft_config is None:
++            return False
++        return "DFlash2DraftModel" in (draft_config.architectures or [])
++
+     def _dflash_needs_multi_kv_group(self) -> bool:
+         """Whether a DFlash draft mixes sliding-window and full attention."""
+         spec = self.speculative_config
+diff --git a/vllm/model_executor/layers/logits_processor.py b/vllm/model_executor/layers/logits_processor.py
+index 31298a6..e7fd568 100644
+--- a/vllm/model_executor/layers/logits_processor.py
++++ b/vllm/model_executor/layers/logits_processor.py
+@@ -2,6 +2,9 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ """A layer that compute logits from hidden_stats."""
+ 
++from collections.abc import Callable
++from functools import cache
++
+ import torch
+ import torch.nn.functional as F
+ 
+@@ -10,12 +13,43 @@ from vllm.distributed import (
+     tensor_model_parallel_all_gather,
+     tensor_model_parallel_gather,
+ )
++from vllm.logger import init_logger
+ from vllm.model_executor.custom_op import PluggableLayer
+ from vllm.model_executor.layers.vocab_parallel_embedding import (
+     UnquantizedEmbeddingMethod,
+     VocabParallelEmbedding,
+ )
+ from vllm.platforms import current_platform
++from vllm.utils.flashinfer import has_flashinfer
++
++logger = init_logger(__name__)
++
++
++@cache
++def _flashinfer_topk() -> Callable[..., tuple[torch.Tensor, torch.Tensor]] | None:
++    """FlashInfer's radix top-k, or None for torch.topk.
++
++    The top-k spans the vocabulary, where the radix kernel is about twice
++    torch.topk.
++    """
++    if not current_platform.is_cuda():
++        return None
++    if not has_flashinfer():
++        logger.info_once(
++            "flashinfer is unavailable; vocab-parallel top-k uses torch.topk, "
++            "at roughly half the speed."
++        )
++        return None
++    from flashinfer import top_k
++
++    return top_k
++
++
++def _topk(scores: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
++    impl = _flashinfer_topk()
++    if impl is None or not scores.is_cuda:
++        return torch.topk(scores, k, dim=-1)
++    return impl(scores, k, sorted=True, deterministic=True)
+ 
+ 
+ # --8<-- [start:logits_processor]
+@@ -204,6 +238,53 @@ class LogitsProcessor(PluggableLayer):
+         top_tokens = gathered[:, :, 1].gather(dim=-1, index=max_rank_idx)
+         return top_tokens.squeeze(-1).to(torch.int64)
+ 
++    def get_top_k_tokens(
++        self,
++        lm_head: VocabParallelEmbedding,
++        hidden_states: torch.Tensor,
++        k: int,
++        embedding_bias: torch.Tensor | None = None,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        """Vocab-parallel top-k without all-gathering full logits.
++
++        The `get_top_tokens` reduction widened from one token to k, returning
++        the values as well as the global ids. Communication is
++        O(batch * 2k * tp_size) rather than O(batch * vocab_size).
++
++        Scale and soft cap are applied to the k selected values rather than
++        the whole vocabulary; both are monotonic, so the selection is the same
++        and only k entries are touched.
++        """
++        if self.scale <= 0.0 and self.scale != 1.0:
++            raise ValueError(
++                "The local top-k reduction optimization is not supported for "
++                "non-positive logit scaling factors."
++            )
++
++        logits = self._apply_head(lm_head, hidden_states, embedding_bias)
++
++        # Mask out padding entries beyond org_vocab_size on this shard.
++        num_pad = lm_head.shard_indices.num_org_vocab_padding
++        if num_pad > 0:
++            logits[..., -num_pad:] = -float("inf")
++
++        values, ids = _topk(logits, k)
++        # Convert shard-local indices to global vocab indices.
++        ids = ids.to(torch.int64) + lm_head.shard_indices.org_vocab_start_index
++
++        if lm_head.tp_size > 1:
++            values = tensor_model_parallel_all_gather(values, dim=-1)
++            ids = tensor_model_parallel_all_gather(ids, dim=-1)
++            values, selected = _topk(values, k)
++            ids = ids.gather(-1, selected)
++
++        values = values.float()
++        if self.scale != 1.0:
++            values = values * self.scale
++        if self.soft_cap is not None:
++            values = torch.tanh(values / self.soft_cap) * self.soft_cap
++        return ids, values
++
+     def extra_repr(self) -> str:
+         s = f"vocab_size={self.vocab_size}"
+         s += f", org_vocab_size={self.org_vocab_size}"
+diff --git a/vllm/model_executor/models/qwen3_dflash.py b/vllm/model_executor/models/qwen3_dflash.py
+index 90b2f48..9157a9a 100644
+--- a/vllm/model_executor/models/qwen3_dflash.py
++++ b/vllm/model_executor/models/qwen3_dflash.py
+@@ -56,10 +56,13 @@ _SLIDING_ATTENTION = "sliding_attention"
+ 
+ 
+ def _dflash_layer_causal(config: Qwen3Config, layer_idx: int) -> bool:
+-    """``dflash_config.causal`` overrides all layers; else only SWA layers causal."""
++    """Resolve explicit causality before falling back to legacy layer defaults."""
++    is_causal = getattr(config, "is_causal", None)
++    if is_causal is not None:
++        return bool(is_causal)
+     override = (getattr(config, "dflash_config", None) or {}).get("causal")
+     if override is not None:
+-        return override
++        return bool(override)
+     layer_types = getattr(config, "layer_types", None)
+     return bool(layer_types) and layer_types[layer_idx] == _SLIDING_ATTENTION
+ 
+@@ -344,6 +347,8 @@ class DFlashQwen3DecoderLayer(nn.Module):
+ 
+ @support_torch_compile
+ class DFlashQwen3Model(nn.Module):
++    decoder_layer_cls = DFlashQwen3DecoderLayer
++
+     hf_to_vllm_mapper = WeightsMapper(
+         orig_to_new_substr={"midlayer.": "layers.0."},
+         orig_to_new_stacked={
+@@ -397,7 +402,7 @@ class DFlashQwen3Model(nn.Module):
+ 
+         self.layers = nn.ModuleList(
+             [
+-                DFlashQwen3DecoderLayer(
++                self.decoder_layer_cls(
+                     current_vllm_config,
+                     config=self.config,
+                     layer_idx=layer_idx,
+@@ -662,6 +667,8 @@ class DFlashQwen3Model(nn.Module):
+ 
+ 
+ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
++    model_cls = DFlashQwen3Model
++
+     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+         nn.Module.__init__(self)
+         self.draft_model_config = vllm_config.speculative_config.draft_model_config
+@@ -671,7 +678,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
+         target_layer_num = vllm_config.model_config.get_num_layers(
+             vllm_config.parallel_config
+         )
+-        self.model = DFlashQwen3Model(
++        self.model = self.model_cls(
+             vllm_config=vllm_config,
+             prefix=maybe_prefix(prefix, "model"),
+             start_layer_id=target_layer_num,
+diff --git a/vllm/model_executor/models/qwen3_dflash2.py b/vllm/model_executor/models/qwen3_dflash2.py
+new file mode 100644
+index 0000000..cb02729
+--- /dev/null
++++ b/vllm/model_executor/models/qwen3_dflash2.py
+@@ -0,0 +1,290 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import torch
++import torch.nn.functional as F
++from torch import nn
++
++from vllm.compilation.backends import set_model_tag
++from vllm.compilation.decorators import support_torch_compile
++from vllm.config import CacheConfig, VllmConfig
++from vllm.model_executor.layers.linear import ReplicatedLinear
++from vllm.model_executor.layers.logits_processor import LogitsProcessor
++from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
++
++from .qwen3_dflash import (
++    DFlashQwen3DecoderLayer,
++    DFlashQwen3ForCausalLM,
++    DFlashQwen3Model,
++)
++from .utils import maybe_prefix
++
++
++def _grouped_conv(
++    hidden_states: torch.Tensor,
++    delta: torch.Tensor,
++    base: torch.Tensor,
++    block_size: int,
++    num_groups: int,
++    group_size: int,
++    taps: int,
++) -> torch.Tensor:
++    blocks = hidden_states.unflatten(-1, (num_groups, group_size))
++    coefficients = base.view(1, taps, num_groups, group_size) + delta.unsqueeze(-1)
++    output = coefficients[:, 0] * blocks
++    position = torch.arange(hidden_states.shape[0], device=hidden_states.device)
++    if block_size & (block_size - 1) == 0:
++        position = position & (block_size - 1)
++    else:
++        position = position % block_size
++    for tap in range(1, taps):
++        shifted = F.pad(blocks[:-tap], (0, 0, 0, 0, tap, 0))
++        output += coefficients[:, tap] * shifted * (position >= tap).view(-1, 1, 1)
++    return output.flatten(-2)
++
++
++class DFlashGroupedConv(nn.Module):
++    def __init__(
++        self,
++        hidden_size: int,
++        taps: int,
++        group_size: int,
++        block_size: int,
++        params_dtype: torch.dtype,
++        prefix: str,
++    ) -> None:
++        super().__init__()
++        if hidden_size % group_size:
++            raise ValueError(
++                f"conv_group_size={group_size} must divide hidden_size={hidden_size}."
++            )
++        self.block_size = block_size
++        self.taps = taps
++        self.group_size = group_size
++        self.num_groups = hidden_size // group_size
++        self.base_kernel = nn.Parameter(
++            torch.empty(2, taps, hidden_size, dtype=params_dtype),
++            requires_grad=False,
++        )
++        self.kernel_projection = ReplicatedLinear(
++            hidden_size,
++            2 * taps * self.num_groups,
++            bias=False,
++            params_dtype=params_dtype,
++            quant_config=None,
++            prefix=maybe_prefix(prefix, "kernel_projection"),
++            return_bias=False,
++        )
++
++    def _convolve(
++        self, hidden_states: torch.Tensor, delta: torch.Tensor, side: int
++    ) -> torch.Tensor:
++        return _grouped_conv(
++            hidden_states,
++            delta,
++            self.base_kernel[side],
++            self.block_size,
++            self.num_groups,
++            self.group_size,
++            self.taps,
++        )
++
++    def prepare(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
++        coefficients = self.kernel_projection(hidden_states).reshape(
++            hidden_states.shape[0], 2, self.taps, self.num_groups
++        )
++        return self._convolve(hidden_states, coefficients[:, 0], 0), coefficients[:, 1]
++
++    def finish(
++        self, hidden_states: torch.Tensor, coefficients: torch.Tensor
++    ) -> torch.Tensor:
++        return self._convolve(hidden_states, coefficients, 1)
++
++
++class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
++    def __init__(
++        self,
++        vllm_config: VllmConfig,
++        *,
++        config,
++        layer_idx: int,
++        cache_config: CacheConfig | None = None,
++        quant_config: QuantizationConfig | None = None,
++        prefix: str = "",
++    ) -> None:
++        super().__init__(
++            vllm_config,
++            config=config,
++            layer_idx=layer_idx,
++            cache_config=cache_config,
++            quant_config=quant_config,
++            prefix=prefix,
++        )
++        draft_config = config.dflash_config
++        speculative_config = vllm_config.speculative_config
++        assert speculative_config is not None
++        conv_args = dict(
++            hidden_size=config.hidden_size,
++            taps=int(draft_config["conv_kernel_size"]),
++            group_size=int(draft_config["conv_group_size"]),
++            # Query tokens per request: the bonus token plus the mask tokens.
++            block_size=1 + speculative_config.num_speculative_tokens,
++            params_dtype=vllm_config.model_config.dtype,
++        )
++        self.attention_conv = DFlashGroupedConv(
++            **conv_args, prefix=maybe_prefix(prefix, "attention_conv")
++        )
++        self.mlp_conv = DFlashGroupedConv(
++            **conv_args, prefix=maybe_prefix(prefix, "mlp_conv")
++        )
++
++    def forward(
++        self,
++        positions: torch.Tensor,
++        hidden_states: torch.Tensor,
++        residual: torch.Tensor | None,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        if residual is None:
++            residual = hidden_states
++            hidden_states = self.input_layernorm(hidden_states)
++        else:
++            hidden_states, residual = self.input_layernorm(hidden_states, residual)
++
++        hidden_states, coefficients = self.attention_conv.prepare(hidden_states)
++        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
++        hidden_states = self.attention_conv.finish(hidden_states, coefficients)
++
++        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
++        hidden_states, coefficients = self.mlp_conv.prepare(hidden_states)
++        hidden_states = self.mlp(hidden_states)
++        hidden_states = self.mlp_conv.finish(hidden_states, coefficients)
++        return hidden_states, residual
++
++
++def _score_edges(
++    predecessor_table: torch.Tensor,
++    successor_table: torch.Tensor,
++    candidate_ids: torch.Tensor,
++    unary_logits: torch.Tensor,
++    hidden: torch.Tensor,
++    anchor_token_ids: torch.Tensor,
++    top_k: int,
++) -> torch.Tensor:
++    successors = successor_table[candidate_ids]
++    predecessor_ids = torch.cat(
++        (
++            anchor_token_ids[:, None, None].expand(-1, 1, top_k),
++            candidate_ids[:, :-1],
++        ),
++        dim=1,
++    )
++    predecessors = predecessor_table[predecessor_ids]
++    return unary_logits[:, :, None] + torch.einsum(
++        "blpr,blcr->blpc", predecessors * hidden[:, :, None], successors
++    )
++
++
++@support_torch_compile
++class CandidateSelector(nn.Module):
++    def __init__(
++        self,
++        hidden_size: int,
++        vocab_size: int,
++        rank: int,
++        top_k: int,
++        params_dtype: torch.dtype,
++        prefix: str,
++    ) -> None:
++        super().__init__()
++        self.top_k = top_k
++        self.predecessor_codebook = nn.Parameter(
++            torch.empty(vocab_size, rank, dtype=params_dtype), requires_grad=False
++        )
++        self.successor_codebook = nn.Parameter(
++            torch.empty(vocab_size, rank, dtype=params_dtype), requires_grad=False
++        )
++        self.hidden_projection = ReplicatedLinear(
++            hidden_size,
++            rank,
++            bias=False,
++            params_dtype=params_dtype,
++            quant_config=None,
++            prefix=maybe_prefix(prefix, "hidden_projection"),
++            return_bias=False,
++        )
++
++    def forward(
++        self,
++        candidate_ids: torch.Tensor,
++        unary_logits: torch.Tensor,
++        hidden_states: torch.Tensor,
++        anchor_token_ids: torch.Tensor,
++    ) -> torch.Tensor:
++        hidden = self.hidden_projection(hidden_states)
++        return _score_edges(
++            self.predecessor_codebook,
++            self.successor_codebook,
++            candidate_ids,
++            unary_logits,
++            hidden,
++            anchor_token_ids,
++            self.top_k,
++        )
++
++
++class DFlash2Qwen3Model(DFlashQwen3Model):
++    decoder_layer_cls = DFlash2Qwen3DecoderLayer
++
++    def __init__(
++        self,
++        *,
++        vllm_config: VllmConfig,
++        start_layer_id: int = 0,
++        prefix: str = "",
++    ) -> None:
++        super().__init__(
++            vllm_config=vllm_config,
++            start_layer_id=start_layer_id,
++            prefix=prefix,
++        )
++        draft_config = self.config.dflash_config
++        self.input_embedding_scale = float(
++            draft_config.get("input_embedding_scale", 1.0)
++        )
++        # Without its own tag the selector shares the draft head's compile cache.
++        with set_model_tag("dflash2_candidate_selector"):
++            self.candidate_selector = CandidateSelector(
++                hidden_size=self.config.hidden_size,
++                vocab_size=self.config.vocab_size,
++                rank=int(draft_config["selector_rank"]),
++                top_k=int(draft_config["selector_top_k"]),
++                params_dtype=vllm_config.model_config.dtype,
++                prefix=maybe_prefix(prefix, "candidate_selector"),
++            )
++
++    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
++        return super().embed_input_ids(input_ids) * self.input_embedding_scale
++
++
++class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
++    model_cls = DFlash2Qwen3Model
++
++    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
++        super().__init__(vllm_config=vllm_config, prefix=prefix)
++        draft_config = self.config.dflash_config
++        softcap = float(draft_config.get("final_logit_softcapping") or 0.0)
++        self.candidate_logits_processor = LogitsProcessor(
++            vllm_config.model_config.get_vocab_size(),
++            scale=float(draft_config.get("output_multiplier", 1.0)),
++            soft_cap=softcap if softcap > 0 else None,
++        )
++
++    def compute_candidates(
++        self, hidden_states: torch.Tensor
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        return self.candidate_logits_processor.get_top_k_tokens(
++            self.lm_head, hidden_states, self.model.candidate_selector.top_k
++        )
++
++
++EntryClass = DFlash2Qwen3ForCausalLM
+diff --git a/vllm/model_executor/models/registry.py b/vllm/model_executor/models/registry.py
+index f412c12..cadd3e1 100644
+--- a/vllm/model_executor/models/registry.py
++++ b/vllm/model_executor/models/registry.py
+@@ -628,6 +628,7 @@ _SPECULATIVE_DECODING_MODELS = {
+     "EagleLlama4ForCausalLM": ("llama4_eagle", "EagleLlama4ForCausalLM"),
+     "EagleMiniCPMForCausalLM": ("minicpm_eagle", "EagleMiniCPMForCausalLM"),
+     "DFlashDraftModel": ("qwen3_dflash", "DFlashQwen3ForCausalLM"),
++    "DFlash2DraftModel": ("qwen3_dflash2", "DFlash2Qwen3ForCausalLM"),
+     "DSparkDraftModel": ("vllm.models.deepseek_v4", "DSparkDeepseekV4ForCausalLM"),
+     "Qwen3DSparkModel": ("qwen3_dspark", "Qwen3DSparkForCausalLM"),
+     "K3DSparkModel": (
+diff --git a/vllm/v1/worker/gpu/sample/gumbel.py b/vllm/v1/worker/gpu/sample/gumbel.py
+index 0a930b8..28c6e0f 100644
+--- a/vllm/v1/worker/gpu/sample/gumbel.py
++++ b/vllm/v1/worker/gpu/sample/gumbel.py
+@@ -81,6 +81,46 @@ def tl_rand32(seed, offset, includes_zero: tl.constexpr):
+     return u
+ 
+ 
++@triton.jit
++def gumbel_noised_argmax(
++    logits,
++    keys,
++    mask,
++    seed,
++    pos,
++    temp,
++    USE_FP64: tl.constexpr,
++    APPLY_TEMPERATURE: tl.constexpr = True,
++):
++    """Argmax of logits under Gumbel-max sampling, or plain argmax at temp 0.
++
++    `keys` indexes the noise, so the same token draws the same noise wherever it
++    appears; `pos` and `seed` place the draw in the request's stream, which is
++    what lets a draft and its verification agree.
++    """
++    if temp != 0.0 and APPLY_TEMPERATURE:
++        # Match the behavior of _temperature_kernel: if that kernel uses
++        # tl.div_rn, this must too.
++        logits = logits / temp
++
++    # fp32 is the default reduction dtype; fp64 is ~1/32-1/64x the throughput
++    # on H100/Ada/Blackwell and empirically indistinguishable for Gumbel-max.
++    if USE_FP64:
++        logits = logits.to(tl.float64)
++    if temp != 0.0:
++        gumbel_seed = tl.randint(seed, pos)
++        if USE_FP64:
++            u = tl_rand64(gumbel_seed, keys, includes_zero=False)
++            gumbel_noise = -tl.log(-tl.log(u))
++        else:
++            u = tl_rand32(gumbel_seed, keys, includes_zero=False)
++            # log1p keeps the winning tail at u -> 0, where fp32 resolves it.
++            gumbel_noise = -tl.log(-tldevice.log1p(-u))
++        logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
++
++    return tl.max(logits, axis=0, return_indices=True)
++
++
+ @triton.jit
+ def gumbel_block_argmax(
+     logits,
+@@ -122,40 +162,18 @@ def gumbel_block_argmax(
+             mask=mask & is_valid_req,
+         )
+ 
+-    if temp != 0.0 and APPLY_TEMPERATURE:
+-        # Apply temperature.
+-        # NOTE(woosuk): Match the behavior of _temperature_kernel.
+-        # E.g., if the kernel uses tl.div_rn, we should use tl.div_rn here too.
+-        logits = logits / temp
+-
+-    # fp32 is the default reduction dtype; fp64 is ~1/32–1/64x the throughput
+-    # on H100/Ada/Blackwell and empirically indistinguishable for Gumbel-max.
+-    if USE_FP64:
+-        logits = logits.to(tl.float64)
+-    if temp != 0.0:
+-        # Calculate the seed for gumbel noise.
+-        seed = tl.load(seeds_ptr + req_state_idx, mask=is_valid_req, other=0)
+-        pos = tl.load(pos_ptr + token_idx)
+-        gumbel_seed = tl.randint(seed, pos)
+-
+-        if USE_FP64:
+-            u = tl_rand64(gumbel_seed, block, includes_zero=False)
+-            gumbel_noise = -tl.log(-tl.log(u))
+-        else:
+-            u = tl_rand32(gumbel_seed, block, includes_zero=False)
+-            # Draw the large-noise tail (which decides the argmax winner) from u -> 0,
+-            # where fp32 has fine resolution, instead of u -> 1, where fp32 spacing is
+-            # ~2**-24. The naive `-log(-log(u))` puts the winning tail at u -> 1,
+-            # hard-capping the noise at ~16.6 and coarsely quantizing it; using
+-            # `log1p(-u)` == `log(1 - u)` keeps the tail in the well-resolved region.
+-            # Note `1 - u` would lose precision for small u, so `log1p` is required.
+-            gumbel_noise = -tl.log(-tldevice.log1p(-u))
+-
+-        # Apply gumbel noise.
+-        logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
+-
+-    value, idx = tl.max(logits, axis=0, return_indices=True)
+-    return value, idx
++    seed = tl.load(seeds_ptr + req_state_idx, mask=is_valid_req, other=0)
++    pos = tl.load(pos_ptr + token_idx)
++    return gumbel_noised_argmax(
++        logits,
++        block,
++        mask,
++        seed,
++        pos,
++        temp,
++        USE_FP64=USE_FP64,
++        APPLY_TEMPERATURE=APPLY_TEMPERATURE,
++    )
+ 
+ 
+ @triton.jit
+diff --git a/vllm/v1/worker/gpu/spec_decode/__init__.py b/vllm/v1/worker/gpu/spec_decode/__init__.py
+index c70f169..927846b 100644
+--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
++++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
+@@ -9,6 +9,12 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
+     speculative_config = vllm_config.speculative_config
+     assert speculative_config is not None
+     if speculative_config.method == "dflash":
++        if "DFlash2DraftModel" in speculative_config.draft_model_config.architectures:
++            from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
++                DFlash2Speculator,
++            )
++
++            return DFlash2Speculator(vllm_config, device)
+         from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
+             DFlashSpeculator,
+         )
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash2/__init__.py b/vllm/v1/worker/gpu/spec_decode/dflash2/__init__.py
+new file mode 100644
+index 0000000..208f01a
+--- /dev/null
++++ b/vllm/v1/worker/gpu/spec_decode/dflash2/__init__.py
+@@ -0,0 +1,2 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+new file mode 100644
+index 0000000..621afc3
+--- /dev/null
++++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+@@ -0,0 +1,215 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from typing import Any
++
++import torch
++
++from vllm.config import VllmConfig
++from vllm.config.compilation import CUDAGraphMode
++from vllm.triton_utils import tl, triton
++from vllm.v1.worker.gpu.sample.gumbel import gumbel_noised_argmax
++from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
++
++
++@triton.jit
++def _selector_walk_kernel(
++    scores_ptr,
++    candidate_ptr,
++    sample_pos_ptr,
++    req_state_ptr,
++    temperature_ptr,
++    seeds_ptr,
++    tokens_ptr,
++    realized_scores_ptr,
++    num_steps: tl.constexpr,
++    top_k: tl.constexpr,
++    BLOCK_K: tl.constexpr,
++    SAMPLE_PROBABILISTIC: tl.constexpr,
++    USE_FP64: tl.constexpr,
++):
++    row = tl.program_id(0)
++    offsets = tl.arange(0, BLOCK_K)
++    mask = offsets < top_k
++    req_state = tl.load(req_state_ptr + row * num_steps)
++    valid = req_state >= 0
++    temperature = tl.load(temperature_ptr + req_state, mask=valid, other=0.0)
++    seed = tl.load(seeds_ptr + req_state, mask=valid, other=0)
++    previous = 0
++    for step in range(num_steps):
++        flat = row * num_steps + step
++        score_base = (flat * top_k + previous) * top_k
++        scores = tl.load(
++            scores_ptr + score_base + offsets,
++            mask=mask & valid,
++            other=float("-inf"),
++        ).to(tl.float64 if USE_FP64 else tl.float32)
++        candidate_base = flat * top_k
++        candidates = tl.load(
++            candidate_ptr + candidate_base + offsets,
++            mask=mask & valid,
++            other=0,
++        )
++
++        # Candidate ids key the noise, matching the target's own sampling.
++        position = tl.load(sample_pos_ptr + flat) - 1
++        _, index = gumbel_noised_argmax(
++            scores,
++            candidates,
++            mask & valid,
++            seed,
++            position,
++            temperature if SAMPLE_PROBABILISTIC else 0.0,
++            USE_FP64=USE_FP64,
++        )
++
++        tl.store(
++            realized_scores_ptr + candidate_base + offsets,
++            scores,
++            mask=mask & valid,
++        )
++        token = tl.load(candidate_ptr + candidate_base + index, mask=valid, other=0)
++        tl.store(tokens_ptr + flat, token, mask=valid)
++        previous = index
++
++
++@triton.jit
++def _cache_draft_logits_kernel(
++    draft_logits_ptr,
++    cached_candidate_ptr,
++    candidate_ptr,
++    scores_ptr,
++    req_state_ptr,
++    draft_logits_stride_0,
++    draft_logits_stride_1,
++    num_steps: tl.constexpr,
++    top_k: tl.constexpr,
++    BLOCK_K: tl.constexpr,
++):
++    flat = tl.program_id(0)
++    req_state = tl.load(req_state_ptr + flat)
++    step = flat % num_steps
++    offsets = tl.arange(0, BLOCK_K)
++    mask = (req_state >= 0) & (offsets < top_k)
++    candidate_base = flat * top_k
++    cache_base = (req_state * num_steps + step) * top_k
++    old_token_ids = tl.load(cached_candidate_ptr + cache_base + offsets, mask=mask)
++    logits_base = (
++        draft_logits_ptr
++        + req_state * draft_logits_stride_0
++        + step * draft_logits_stride_1
++    )
++    tl.store(logits_base + old_token_ids, -float("inf"), mask=mask)
++    token_ids = tl.load(candidate_ptr + candidate_base + offsets, mask=mask)
++    scores = tl.load(scores_ptr + candidate_base + offsets, mask=mask)
++    tl.store(logits_base + token_ids, scores, mask=mask)
++    tl.store(cached_candidate_ptr + cache_base + offsets, token_ids, mask=mask)
++
++
++class DFlash2Speculator(DFlashSpeculator):
++    _speculator_name = "DFlash2"
++
++    def __init__(self, vllm_config: VllmConfig, device: torch.device):
++        super().__init__(vllm_config, device)
++        draft_config = self.draft_model_config.hf_config.dflash_config
++        self.selector_top_k = int(draft_config["selector_top_k"])
++        self._anchor_indices = (
++            torch.arange(self.max_num_reqs, dtype=torch.int64, device=device)
++            * self.num_query_per_req
++        )
++        self._selector_scores = torch.empty(
++            self.max_num_reqs,
++            self.num_speculative_steps,
++            self.selector_top_k,
++            dtype=torch.float32,
++            device=device,
++        )
++        self._cached_candidate_ids = torch.zeros(
++            self._selector_scores.shape, dtype=torch.int64, device=device
++        )
++
++    def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
++        # fp32 so the walk and the rejection that checks it read the same
++        # distribution; -inf because the cache kernel writes only the K
++        # candidates.
++        return torch.float32, -float("inf")
++
++    def _sample_path(
++        self,
++        candidate_ids: torch.Tensor,
++        scores: torch.Tensor,
++        num_reqs: int,
++    ) -> None:
++        block_k = triton.next_power_of_2(self.selector_top_k)
++        _selector_walk_kernel[(num_reqs,)](
++            scores.contiguous(),
++            candidate_ids.contiguous(),
++            self.sample_pos,
++            self.sample_idx_mapping,
++            self.temperature,
++            self.seeds,
++            self.draft_tokens,
++            self._selector_scores,
++            num_steps=self.num_speculative_steps,
++            top_k=self.selector_top_k,
++            BLOCK_K=block_k,
++            SAMPLE_PROBABILISTIC=self.draft_logits is not None,
++            USE_FP64=self.use_fp64_gumbel,
++            num_warps=1,
++        )
++
++    def _cache_draft_logits(self, candidate_ids: torch.Tensor, num_sample: int) -> None:
++        draft_logits = self.draft_logits
++        assert draft_logits is not None
++        block_k = triton.next_power_of_2(self.selector_top_k)
++        _cache_draft_logits_kernel[(num_sample,)](
++            draft_logits,
++            self._cached_candidate_ids,
++            candidate_ids,
++            self._selector_scores,
++            self.sample_idx_mapping,
++            draft_logits.stride(0),
++            draft_logits.stride(1),
++            num_steps=self.num_speculative_steps,
++            top_k=self.selector_top_k,
++            BLOCK_K=block_k,
++            num_warps=1,
++        )
++
++    def _generate_draft(
++        self,
++        num_reqs: int,
++        num_tokens_padded: int,
++        attn_metadata: dict[str, Any] | None,
++        slot_mappings: dict[str, torch.Tensor] | None,
++        num_tokens_across_dp: torch.Tensor | None,
++        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
++    ) -> None:
++        last_hidden_states = self._run_model(
++            num_tokens_padded,
++            attn_metadata,
++            slot_mappings,
++            num_tokens_across_dp,
++            cudagraph_runtime_mode,
++        )
++        num_sample = num_reqs * self.num_speculative_steps
++        hidden_states = last_hidden_states[self.sample_indices[:num_sample]].view(
++            num_reqs, self.num_speculative_steps, -1
++        )
++        candidate_ids, unary_logits = self.model.compute_candidates(
++            hidden_states.flatten(0, 1)
++        )
++        candidate_ids = candidate_ids.view(
++            num_reqs, self.num_speculative_steps, self.selector_top_k
++        )
++        unary_logits = unary_logits.view_as(candidate_ids)
++        anchor_token_ids = self.input_buffers.input_ids[self._anchor_indices[:num_reqs]]
++        scores = self.model.model.candidate_selector(
++            candidate_ids,
++            unary_logits,
++            hidden_states,
++            anchor_token_ids,
++        )
++        self._sample_path(candidate_ids, scores, num_reqs)
++        if self.draft_logits is not None:
++            self._cache_draft_logits(candidate_ids, num_sample)
+diff --git a/vllm/v1/worker/gpu/spec_decode/speculator.py b/vllm/v1/worker/gpu/spec_decode/speculator.py
+index 72a8708..e698708 100644
+--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
+@@ -145,11 +145,15 @@ class DraftModelSpeculator(BaseSpeculator):
+         self.draft_logits: torch.Tensor | None = None
+         if self.speculative_config.draft_sample_method == "probabilistic":
+             # Pre-temperature logits, cached from the previous decode step.
+-            self.draft_logits = torch.zeros(
+-                self.max_num_reqs,
+-                self.num_speculative_steps,
+-                self.vocab_size,
+-                dtype=vllm_config.model_config.head_dtype,
++            dtype, fill = self.draft_logits_spec(vllm_config)
++            self.draft_logits = torch.full(
++                (
++                    self.max_num_reqs,
++                    self.num_speculative_steps,
++                    self.vocab_size,
++                ),
++                fill,
++                dtype=dtype,
+                 device=device,
+             )
+ 
+@@ -300,6 +304,13 @@ class DraftModelSpeculator(BaseSpeculator):
+         )
+         return attn_metadata
+ 
++    def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
++        """Dtype and fill for the cached proposal distribution.
++
++        Speculators that write only a subset of columns each step override this.
++        """
++        return vllm_config.model_config.head_dtype, 0.0
++
+     def _validate_local_argmax_reduction(self) -> None:
+         if not self.use_local_argmax_reduction:
+             return

--- a/docker/patch_v10_dflash_glm5.py
+++ b/docker/patch_v10_dflash_glm5.py
@@ -1,0 +1,135 @@
+"""DFlash aux-hidden-state capture for Glm5Next (fork-only model).
+
+The DFlash/DFlash2 drafter needs target hidden states from the layers named in
+the draft's dflash_config.target_layer_ids. vLLM routes that through the
+EAGLE3 interface (set_eagle3_aux_hidden_state_layers), which Glm5Next does not
+implement -- TP ranks die with "Model does not support EAGLE3 interface".
+
+Capture semantics follow sgl-project/sglang#36708 (the reference DFlash2
+integration for GLM-5.3-Flash): the completed output of layer k, taken at the
+top of iteration k+1, contracted from the n hyper-connection streams to
+nominal width by averaging. In this fork a layer's hc_post is deferred into
+the next layer's fused kernel, so the tap materializes it explicitly;
+MHCPostOp returns a fresh tensor, so the deferred (x, residual, post, comb)
+flow into the next layer is untouched.
+"""
+
+from pathlib import Path
+
+p = Path("/usr/local/lib/python3.12/dist-packages/vllm/models/glm5next/nvidia/model.py")
+s = p.read_text()
+
+old = """from vllm.model_executor.models.interfaces import (
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    SupportsPP,
+)"""
+new = """from vllm.model_executor.models.interfaces import (
+    EagleModelMixin,
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    SupportsEagle3,
+    SupportsPP,
+)"""
+if s.count(old) != 1:
+    raise SystemExit("unexpected interfaces import; refusing to patch")
+s = s.replace(old, new)
+
+old = "class Glm5NextModel(nn.Module):"
+new = "class Glm5NextModel(EagleModelMixin, nn.Module):"
+if s.count(old) != 1:
+    raise SystemExit("unexpected Glm5NextModel class def; refusing to patch")
+s = s.replace(old, new)
+
+old = """        for layer in self._active_layers:
+            hidden_states, residual, post, comb = layer(
+                positions, hidden_states, residual, post, comb
+            )
+"""
+new = """        aux_hidden_states: list[torch.Tensor] = []
+        prev_layer = None
+        for layer_idx, layer in enumerate(
+            self._active_layers, start=self.start_layer
+        ):
+            if layer_idx in self.aux_hidden_state_layers:
+                aux_hidden_states.append(
+                    self._dflash_aux_hidden_state(
+                        hidden_states, residual, post, comb, prev_layer,
+                        full_num_tokens,
+                    )
+                )
+            hidden_states, residual, post, comb = layer(
+                positions, hidden_states, residual, post, comb
+            )
+            prev_layer = layer
+"""
+if s.count(old) != 1:
+    raise SystemExit("unexpected Glm5NextModel layer loop; refusing to patch")
+s = s.replace(old, new)
+
+old = """        hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:"""
+new = """        hidden_states = self.norm(hidden_states)
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+    def _dflash_aux_hidden_state(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        post: torch.Tensor | None,
+        comb: torch.Tensor | None,
+        prev_layer: nn.Module | None,
+        full_num_tokens: int,
+    ) -> torch.Tensor:
+        # Completed output of the previous layer at nominal width. Mid-stack,
+        # a layer's hc_post is deferred into the next layer's fused kernel, so
+        # materialize it here (MHCPostOp returns a fresh tensor) and average
+        # the hyper-connection streams -- the DFlash capture semantics from
+        # sgl-project/sglang#36708.
+        if post is None:
+            aux = hidden_states
+        else:
+            assert prev_layer is not None
+            aux = hc_contract(
+                prev_layer.hc_post(hidden_states, residual, post, comb),
+                prev_layer.n,
+            )
+        if self.is_sequence_parallel:
+            aux = sp_all_gather(aux)[:full_num_tokens]
+        return aux
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:"""
+if s.count(old) != 1:
+    raise SystemExit("unexpected Glm5NextModel forward tail; refusing to patch")
+s = s.replace(old, new)
+
+old = """class Glm5NextForCausalLM(
+    nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid
+):"""
+new = """class Glm5NextForCausalLM(
+    nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid, SupportsEagle3
+):"""
+if s.count(old) != 1:
+    raise SystemExit("unexpected Glm5NextForCausalLM class def; refusing to patch")
+s = s.replace(old, new)
+
+old = """class Glm5NextForConditionalGeneration(
+    Glm4vForConditionalGeneration, HasInnerState, IsHybrid
+):"""
+new = """class Glm5NextForConditionalGeneration(
+    Glm4vForConditionalGeneration, HasInnerState, IsHybrid, SupportsEagle3
+):"""
+if s.count(old) != 1:
+    raise SystemExit(
+        "unexpected Glm5NextForConditionalGeneration class def; refusing to patch"
+    )
+s = s.replace(old, new)
+
+p.write_text(s)
+print("glm5next DFlash aux-hidden-state capture applied")

--- a/docker/patch_v11_dflash_kv_groups.py
+++ b/docker/patch_v11_dflash_kv_groups.py
@@ -1,0 +1,322 @@
+"""DFlash draft KV group for the GLM-5-Next bespoke KV cache layout.
+
+The GLM-5-Next grouping (`_get_kv_cache_groups_glm5_next`) only admits
+MLA/mamba/kpool specs, so a DFlash draft's SlidingWindowSpec layers make it
+bail to the generic path, which cannot unify the indexer's 33 B/token page
+with the draft's page and dies with NotImplementedError.
+
+This patch carves the draft's uniform sliding-window layers into their own KV
+group with dedicated per-layer tensors:
+
+- The draft group adopts the attention group's block size. Every block id in
+  the shared pool is charged the full per-block byte sum, so the draft's
+  default 16-token blocks would burn sliding_window/16 ids per request and
+  exhaust the pool; at the attention block size a request needs 1-2 ids.
+- `_glm5_next_tensor_layout` learns to classify the draft group and returns
+  it to all three consumers (pool bytes per block, tensor emission, max
+  memory estimation), which add len(draft) * draft_page to the per-block sum.
+"""
+
+from pathlib import Path
+
+p = Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_utils.py")
+s = p.read_text()
+
+
+def swap(old: str, new: str, what: str) -> None:
+    global s
+    if s.count(old) != 1:
+        raise SystemExit(f"unexpected source for {what}; refusing to patch")
+    s = s.replace(old, new)
+
+
+# 1. Builder: split draft sliding-window specs out of the attention specs.
+swap(
+    """    attn_specs = {
+        k: v
+        for k, v in kv_cache_spec.items()
+        if not isinstance(v, (MambaSpec, KpoolTailSpec))
+    }
+    if not mamba_specs or not all(
+        type(s) is MLAAttentionSpec for s in attn_specs.values()
+    ):
+        return None""",
+    """    attn_specs = {
+        k: v
+        for k, v in kv_cache_spec.items()
+        if not isinstance(v, (MambaSpec, KpoolTailSpec))
+    }
+    # DFlash draft layers (uniform sliding-window GQA). The target itself has
+    # no SlidingWindowSpec layers, so this split is unambiguous.
+    draft_specs = {
+        k: v for k, v in attn_specs.items() if isinstance(v, SlidingWindowSpec)
+    }
+    attn_specs = {k: v for k, v in attn_specs.items() if k not in draft_specs}
+    if not mamba_specs or not all(
+        type(s) is MLAAttentionSpec for s in attn_specs.values()
+    ):
+        return None""",
+    "glm5 group builder spec split",
+)
+
+# 2. Builder: construct the draft group and append it to the returned groups.
+swap(
+    """    return (
+        [KVCacheGroupSpec(list(attn_specs), uniform_spec)]
+        + ([tail_group] if tail_group is not None else [])
+        + create_kv_cache_group_specs(padded_specs, mamba_grouped_names)
+    )""",
+    """    draft_group = None
+    if draft_specs:
+        # Every pool block id costs the full per-block byte sum, so the
+        # draft's block size trades tensor bytes against block-id burn: tiny
+        # blocks (default 16) need sliding_window/16 ids per request and
+        # exhaust the pool, while a full attention-sized block puts a page of
+        # draft KV behind every target block id. A quarter block keeps a
+        # 2048-token window at ~3 ids per request with a quarter of the
+        # per-block tensor tax.
+        attn_block = next(iter(mla_specs.values())).block_size
+        draft_block = max(attn_block // 4, 16)
+        resized_draft_specs: dict[str, KVCacheSpec] = {
+            name: replace(spec, block_size=draft_block)
+            for name, spec in draft_specs.items()
+        }
+        draft_uniform = UniformTypeKVCacheSpecs.from_specs(resized_draft_specs)
+        assert draft_uniform is not None
+        draft_group = KVCacheGroupSpec(list(resized_draft_specs), draft_uniform)
+
+    return (
+        [KVCacheGroupSpec(list(attn_specs), uniform_spec)]
+        + ([tail_group] if tail_group is not None else [])
+        + ([draft_group] if draft_group is not None else [])
+        + create_kv_cache_group_specs(padded_specs, mamba_grouped_names)
+    )""",
+    "glm5 group builder return",
+)
+
+# 3. Detector signature: two more fields for the draft group.
+swap(
+    """) -> (
+    tuple[
+        KVCacheGroupSpec,
+        list[KVCacheGroupSpec],
+        list[str],
+        list[str],
+        int,
+        int,
+        list[str],
+        int,
+    ]
+    | None
+):""",
+    """) -> (
+    tuple[
+        KVCacheGroupSpec,
+        list[KVCacheGroupSpec],
+        list[str],
+        list[str],
+        int,
+        int,
+        list[str],
+        int,
+        list[str],
+        int,
+    ]
+    | None
+):""",
+    "glm5 layout detector signature",
+)
+
+# 4. Detector: classify the draft group.
+swap(
+    """    for g in uniform_groups:
+        group_inner = cast(UniformTypeKVCacheSpecs, g.kv_cache_spec).kv_cache_specs
+        if all(type(s) is MLAAttentionSpec for s in group_inner.values()):
+            attn_group = g
+        elif all(isinstance(s, KpoolTailSpec) for s in group_inner.values()):
+            tail_group = g""",
+    """    draft_group: KVCacheGroupSpec | None = None
+    for g in uniform_groups:
+        group_inner = cast(UniformTypeKVCacheSpecs, g.kv_cache_spec).kv_cache_specs
+        if all(type(s) is MLAAttentionSpec for s in group_inner.values()):
+            attn_group = g
+        elif all(isinstance(s, KpoolTailSpec) for s in group_inner.values()):
+            tail_group = g
+        elif all(isinstance(s, SlidingWindowSpec) for s in group_inner.values()):
+            # DFlash draft group (uniform sliding-window GQA layers).
+            draft_group = g""",
+    "glm5 layout detector classification",
+)
+
+# 5. Detector: return the draft fields.
+swap(
+    """    return (
+        attn_group,
+        mamba_groups,
+        mla_names,
+        idx_names,
+        mla_page,
+        idx_pages.pop(),
+        tail_names,
+        tail_page,
+    )""",
+    """    draft_names: list[str] = []
+    draft_page = 0
+    if draft_group is not None:
+        draft_names = list(draft_group.layer_names)
+        draft_pages = {
+            spec.page_size_bytes
+            for spec in cast(
+                UniformTypeKVCacheSpecs, draft_group.kv_cache_spec
+            ).kv_cache_specs.values()
+        }
+        if len(draft_pages) != 1:
+            return None
+        draft_page = draft_pages.pop()
+
+    return (
+        attn_group,
+        mamba_groups,
+        mla_names,
+        idx_names,
+        mla_page,
+        idx_pages.pop(),
+        tail_names,
+        tail_page,
+        draft_names,
+        draft_page,
+    )""",
+    "glm5 layout detector return",
+)
+
+# 6. Pool bytes per block: charge draft tensors on every block id.
+swap(
+    """        _, _, mla_names, idx_names, mla_page, idx_page, _, _ = glm5
+        return len(mla_names) * mla_page + len(idx_names) * idx_page""",
+    """        _, _, mla_names, idx_names, mla_page, idx_page, _, _, dr_names, dr_page = (
+            glm5
+        )
+        return (
+            len(mla_names) * mla_page
+            + len(idx_names) * idx_page
+            + len(dr_names) * dr_page
+        )""",
+    "pool bytes per block",
+)
+
+# 7. Tensor emission: size the pool with draft pages and emit draft tensors.
+swap(
+    """        (
+            _,
+            mamba_groups,
+            mla_names,
+            idx_names,
+            mla_page,
+            idx_page,
+            tail_names,
+            _tail_page,
+        ) = glm5n""",
+    """        (
+            _,
+            mamba_groups,
+            mla_names,
+            idx_names,
+            mla_page,
+            idx_page,
+            tail_names,
+            _tail_page,
+            draft_names,
+            draft_page,
+        ) = glm5n""",
+    "tensor emission unpack",
+)
+
+swap(
+    """        per_block = len(mla_names) * mla_page + len(idx_names) * idx_page
+        num_blocks = available_memory // per_block""",
+    """        per_block = (
+            len(mla_names) * mla_page
+            + len(idx_names) * idx_page
+            + len(draft_names) * draft_page
+        )
+        num_blocks = available_memory // per_block""",
+    "tensor emission per-block",
+)
+
+swap(
+    """            KVCacheTensor(
+                size=idx_page * num_blocks,
+                shared_by=(
+                    [idx_names[i], tail_names[i]] if tail_names else [idx_names[i]]
+                ),
+            )
+            for i in range(len(idx_names))
+        ]""",
+    """            KVCacheTensor(
+                size=idx_page * num_blocks,
+                shared_by=(
+                    [idx_names[i], tail_names[i]] if tail_names else [idx_names[i]]
+                ),
+            )
+            for i in range(len(idx_names))
+        ] + [
+            KVCacheTensor(size=draft_page * num_blocks, shared_by=[draft_name])
+            for draft_name in draft_names
+        ]""",
+    "tensor emission draft tensors",
+)
+
+# 8. Max-memory estimator: account for draft block-id demand and pages.
+swap(
+    """        (
+            attn_group,
+            mamba_groups,
+            mla_names,
+            idx_names,
+            mla_page,
+            idx_page,
+            tail_names,
+            _tail_page,
+        ) = glm5n
+        uniform_spec = attn_group.kv_cache_spec
+        assert isinstance(uniform_spec, UniformTypeKVCacheSpecs)
+        blocks_needed = uniform_spec.max_memory_usage_pages(vllm_config)""",
+    """        (
+            attn_group,
+            mamba_groups,
+            mla_names,
+            idx_names,
+            mla_page,
+            idx_page,
+            tail_names,
+            _tail_page,
+            draft_names,
+            draft_page,
+        ) = glm5n
+        uniform_spec = attn_group.kv_cache_spec
+        assert isinstance(uniform_spec, UniformTypeKVCacheSpecs)
+        blocks_needed = uniform_spec.max_memory_usage_pages(vllm_config)""",
+    "estimator unpack",
+)
+
+swap(
+    """        return blocks_needed * (len(mla_names) * mla_page + len(idx_names) * idx_page)""",
+    """        if draft_names:
+            # Sliding-window draft: window/block_size + 1 ids per request.
+            draft_uniform = None
+            for g in kv_cache_groups:
+                if list(g.layer_names) == draft_names:
+                    draft_uniform = g.kv_cache_spec
+                    break
+            assert isinstance(draft_uniform, UniformTypeKVCacheSpecs)
+            blocks_needed += draft_uniform.max_memory_usage_pages(vllm_config)
+        return blocks_needed * (
+            len(mla_names) * mla_page
+            + len(idx_names) * idx_page
+            + len(draft_names) * draft_page
+        )""",
+    "estimator return",
+)
+
+p.write_text(s)
+print("glm5next DFlash draft KV group applied")

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 MODEL="${MODEL:-LibertAIDAI/GLM-5.3-Flash-NVFP4}"
 SERVED_NAME="${SERVED_NAME:-LibertAIDAI/GLM-5.3-Flash-NVFP4}"
-IMAGE="${IMAGE:-glm53-sm121-v8}"
+IMAGE="${IMAGE:-glm53-sm121-v11}"
 CONTAINER_NAME="${CONTAINER_NAME:-glm53-flash-nvfp4}"
 PORT="${PORT:-8000}"
 MASTER_PORT="${MASTER_PORT:-29521}"
@@ -14,11 +14,13 @@ IFACE="${IFACE:-enp1s0f1np1}"
 HCA="${HCA:-rocep1s0f1}"
 TP="${TP:-2}"
 NNODES="${NNODES:-2}"
-MAX_MODEL_LEN="${MAX_MODEL_LEN:-262144}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-327680}"
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
 UTIL="${UTIL:-0.85}"
-# GB10 UMA: 4.14 GiB is the only KV pin that kept MTP-4 alive on TP=2.
-# Raising it or dropping the pin OOMs (NV_ERR_NO_MEMORY).
+# GB10 UMA: 4.14 GiB is the safe KV pin on TP=2. Dropping the pin OOMs
+# (NV_ERR_NO_MEMORY). Raising it boots but degrades: 5.0 GiB slowed decode
+# ~20% at every concurrency (UMA pressure), and 5.14 GiB crashed under
+# concurrent load.
 KV_CACHE_MEMORY="${KV_CACHE_MEMORY:-4445787956}"
 # DeepGEMM arch-12 fp8 paged-MQA only accepts 64-entry pool pages. 2304 tiles that.
 BLOCK_SIZE="${BLOCK_SIZE:-2304}"
@@ -30,12 +32,15 @@ DRAFT_MODEL="${DRAFT_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
 DRAFT_SNAPSHOT="${HF_CACHE}/hub/models--incoai--GLM-5.3-Flash-DFlash2/snapshots/7d74cdd881ed7e32c31175984a67823127b66cfe"
 DRAFT_SNAPSHOT_IN_CONTAINER="${HF_HOME_IN_CONTAINER}/hub/models--incoai--GLM-5.3-Flash-DFlash2/snapshots/7d74cdd881ed7e32c31175984a67823127b66cfe"
 # SPEC picks the drafter: dflash2 (incoai DFlash2 block-diffusion draft, needs
-# the glm53-sm121-v9 image) or mtp (GLM's native MTP head).
-SPEC="${SPEC:-mtp}"
+# the glm53-sm121-v11 image) or mtp (GLM's native MTP head).
+SPEC="${SPEC:-dflash2}"
 if [[ -z "${SPEC_CONFIG:-}" ]]; then
   case "$SPEC" in
     dflash2)
-      SPEC_CONFIG='{"method":"dflash","model":"'"$DRAFT_SNAPSHOT_IN_CONTAINER"'","num_speculative_tokens":7}'
+      # 5 of the block's 7 draft slots: positions 5-6 accept <15% of the
+      # time, and every extra slot costs a KDA state copy per sequence
+      # (num_spec+1 copies), which is what starves c=4 admission at 7.
+      SPEC_CONFIG='{"method":"dflash","model":"'"$DRAFT_SNAPSHOT_IN_CONTAINER"'","num_speculative_tokens":5}'
       ;;
     mtp)
       SPEC_CONFIG='{"method":"mtp","num_speculative_tokens":4}'
@@ -104,7 +109,7 @@ maybe_drop_caches() {
 ensure_image() {
   log "Ensuring image $IMAGE"
   if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-    echo "Image $IMAGE not found. Build the local glm53-sm121-v8 tag first. Do not use stock vllm/vllm-openai on sm_121." >&2
+    echo "Image $IMAGE not found. Build the local image chain through glm53-sm121-v11 first (see README). Do not use stock vllm/vllm-openai on sm_121." >&2
     exit 1
   fi
 }

--- a/run.sh
+++ b/run.sh
@@ -26,6 +26,26 @@ HF_CACHE="${HF_CACHE:-$HOME/.cache/huggingface}"
 HF_HOME_IN_CONTAINER="/cache/huggingface"
 SNAPSHOT="${HF_CACHE}/hub/models--LibertAIDAI--GLM-5.3-Flash-NVFP4/snapshots/aa28e1f54130286c95fee10d0705c74ce8743734"
 SNAPSHOT_IN_CONTAINER="${HF_HOME_IN_CONTAINER}/hub/models--LibertAIDAI--GLM-5.3-Flash-NVFP4/snapshots/aa28e1f54130286c95fee10d0705c74ce8743734"
+DRAFT_MODEL="${DRAFT_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
+DRAFT_SNAPSHOT="${HF_CACHE}/hub/models--incoai--GLM-5.3-Flash-DFlash2/snapshots/7d74cdd881ed7e32c31175984a67823127b66cfe"
+DRAFT_SNAPSHOT_IN_CONTAINER="${HF_HOME_IN_CONTAINER}/hub/models--incoai--GLM-5.3-Flash-DFlash2/snapshots/7d74cdd881ed7e32c31175984a67823127b66cfe"
+# SPEC picks the drafter: dflash2 (incoai DFlash2 block-diffusion draft, needs
+# the glm53-sm121-v9 image) or mtp (GLM's native MTP head).
+SPEC="${SPEC:-mtp}"
+if [[ -z "${SPEC_CONFIG:-}" ]]; then
+  case "$SPEC" in
+    dflash2)
+      SPEC_CONFIG='{"method":"dflash","model":"'"$DRAFT_SNAPSHOT_IN_CONTAINER"'","num_speculative_tokens":7}'
+      ;;
+    mtp)
+      SPEC_CONFIG='{"method":"mtp","num_speculative_tokens":4}'
+      ;;
+    *)
+      echo "Unknown SPEC=$SPEC (want dflash2 or mtp)" >&2
+      exit 1
+      ;;
+  esac
+fi
 SKIP_DOWNLOAD="${SKIP_DOWNLOAD:-0}"
 ORCHESTRATE="${ORCHESTRATE:-auto}"
 
@@ -91,16 +111,31 @@ ensure_weights() {
   if [[ "$SKIP_DOWNLOAD" == "1" ]]; then
     return
   fi
+  local HF=""
+  HF="$(hf_bin || true)"
   if [[ -d "$SNAPSHOT" ]]; then
     log "Using pinned snapshot $SNAPSHOT"
-    return
-  fi
-  if HF=$(hf_bin); then
+  elif [[ -n "$HF" ]]; then
     export HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}"
     log "Downloading $MODEL (resumes under $HF_CACHE)"
     "$HF" download "$MODEL"
   else
     log "No hf CLI on PATH — vLLM will pull weights on first load"
+  fi
+  if [[ "$SPEC_CONFIG" != *'"dflash"'* ]]; then
+    return
+  fi
+  if [[ -d "$DRAFT_SNAPSHOT" ]]; then
+    log "Using pinned draft snapshot $DRAFT_SNAPSHOT"
+  elif [[ -n "$HF" ]]; then
+    export HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}"
+    log "Downloading $DRAFT_MODEL (resumes under $HF_CACHE)"
+    "$HF" download "$DRAFT_MODEL"
+  else
+    # The dflash config points at the pinned snapshot path inside the
+    # container, so vLLM cannot pull it on demand.
+    echo "Draft snapshot $DRAFT_SNAPSHOT missing and no hf CLI on PATH." >&2
+    exit 1
   fi
 }
 
@@ -193,7 +228,7 @@ start_local() {
     --enforce-eager \
     --block-size "$BLOCK_SIZE" \
     --moe-backend marlin \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":4}' \
+    --speculative-config "$SPEC_CONFIG" \
     --tool-call-parser glm47 \
     --enable-auto-tool-choice \
     --reasoning-parser glm45 \
@@ -235,7 +270,7 @@ if [[ "$ORCHESTRATE" == "auto" && "$ROLE" == "head" ]]; then
     log "Starting worker on $WORKER_HOST first"
     scp -q "$0" "${WORKER_HOST}:/tmp/glm53-run.sh"
     ssh "$WORKER_HOST" \
-      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' bash /tmp/glm53-run.sh"
+      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC_CONFIG='$SPEC_CONFIG' bash /tmp/glm53-run.sh"
     log "Worker container started. Waiting 25s for NCCL listen, then starting head"
     sleep 25
   else

--- a/run.sh
+++ b/run.sh
@@ -51,6 +51,16 @@ if [[ -z "${SPEC_CONFIG:-}" ]]; then
       ;;
   esac
 fi
+# CUDA graphs (default). Measured vs eager on this cluster: prose 28.2/21.1/17.1
+# vs 27.6/20.0/17.1 per stream at c=1/2/4, structured 51.4/41.5/35.7 vs
+# 49.6/41.8/35.0. Zero capture memory cost, same 400,497-token KV pool.
+# ENFORCE_EAGER=1 is the rollback. The runner rounds capture sizes up to
+# multiples of num_speculative_tokens+1, so for DFlash2-5 the FULL-graph ladder
+# lands on 6/12/18/24, the verify shapes for 1-4 sequences at max-num-seqs 4.
+ENFORCE_EAGER="${ENFORCE_EAGER:-0}"
+if [[ -z "${COMPILATION_CONFIG:-}" ]]; then
+  COMPILATION_CONFIG='{"cudagraph_capture_sizes":[1,2,4,6,12,18,24]}'
+fi
 SKIP_DOWNLOAD="${SKIP_DOWNLOAD:-0}"
 ORCHESTRATE="${ORCHESTRATE:-auto}"
 # Extra vllm serve args, word-split on purpose (e.g. "--load-format dummy").
@@ -205,7 +215,14 @@ start_local() {
     rank_args+=(--headless)
   fi
 
-  log "Starting $CONTAINER_NAME rank=$rank model=$serve_model ctx=$MAX_MODEL_LEN kv=$KV_CACHE_MEMORY"
+  local eager_args=()
+  if [[ "$ENFORCE_EAGER" == "1" ]]; then
+    eager_args+=(--enforce-eager)
+  else
+    eager_args+=(--compilation-config "$COMPILATION_CONFIG")
+  fi
+
+  log "Starting $CONTAINER_NAME rank=$rank model=$serve_model ctx=$MAX_MODEL_LEN kv=$KV_CACHE_MEMORY eager=$ENFORCE_EAGER"
   docker run -d \
     --name "$CONTAINER_NAME" \
     --restart no \
@@ -232,7 +249,7 @@ start_local() {
     --kv-cache-memory "$KV_CACHE_MEMORY" \
     --gpu-memory-utilization "$UTIL" \
     --max-num-seqs "$MAX_NUM_SEQS" \
-    --enforce-eager \
+    "${eager_args[@]}" \
     --block-size "$BLOCK_SIZE" \
     --moe-backend marlin \
     --speculative-config "$SPEC_CONFIG" \
@@ -278,7 +295,7 @@ if [[ "$ORCHESTRATE" == "auto" && "$ROLE" == "head" ]]; then
     log "Starting worker on $WORKER_HOST first"
     scp -q "$0" "${WORKER_HOST}:/tmp/glm53-run.sh"
     ssh "$WORKER_HOST" \
-      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC_CONFIG='$SPEC_CONFIG' EXTRA_ARGS='$EXTRA_ARGS' bash /tmp/glm53-run.sh"
+      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC_CONFIG='$SPEC_CONFIG' ENFORCE_EAGER='$ENFORCE_EAGER' COMPILATION_CONFIG='$COMPILATION_CONFIG' EXTRA_ARGS='$EXTRA_ARGS' bash /tmp/glm53-run.sh"
     log "Worker container started. Waiting 25s for NCCL listen, then starting head"
     sleep 25
   else

--- a/run.sh
+++ b/run.sh
@@ -48,6 +48,8 @@ if [[ -z "${SPEC_CONFIG:-}" ]]; then
 fi
 SKIP_DOWNLOAD="${SKIP_DOWNLOAD:-0}"
 ORCHESTRATE="${ORCHESTRATE:-auto}"
+# Extra vllm serve args, word-split on purpose (e.g. "--load-format dummy").
+EXTRA_ARGS="${EXTRA_ARGS:-}"
 
 log() { printf '==> %s\n' "$*"; }
 
@@ -234,7 +236,8 @@ start_local() {
     --reasoning-parser glm45 \
     --default-chat-template-kwargs '{"enable_thinking": false}' \
     --served-model-name "$SERVED_NAME" \
-    --trust-remote-code
+    --trust-remote-code \
+    $EXTRA_ARGS
 }
 
 wait_ready() {
@@ -270,7 +273,7 @@ if [[ "$ORCHESTRATE" == "auto" && "$ROLE" == "head" ]]; then
     log "Starting worker on $WORKER_HOST first"
     scp -q "$0" "${WORKER_HOST}:/tmp/glm53-run.sh"
     ssh "$WORKER_HOST" \
-      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC_CONFIG='$SPEC_CONFIG' bash /tmp/glm53-run.sh"
+      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC_CONFIG='$SPEC_CONFIG' EXTRA_ARGS='$EXTRA_ARGS' bash /tmp/glm53-run.sh"
     log "Worker container started. Waiting 25s for NCCL listen, then starting head"
     sleep 25
   else


### PR DESCRIPTION
## What

Makes DFlash2 ([incoai/GLM-5.3-Flash-DFlash2](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2)) the recipe's default drafter, replacing MTP-4, and turns on CUDA graphs, both with independently verified benchmarks.

- `docker/dflash2_backport.diff` + `Dockerfile.sm121-v9`: vLLM PR [#52816](https://github.com/vllm-project/vllm/pull/52816) (DFlash2) backported as an exact-context patch onto the sm_121 image (two upstream hunks misplace under fuzzy application; corrected here).
- `docker/patch_v10_dflash_glm5.py` + `Dockerfile.sm121-v10`: the fork-only Glm5Next model lacked the EAGLE3 aux-hidden-state interface DFlash taps target features through. Implements the capture with mHC hyper-connection semantics verified against the SGLang reference integration (sgl-project/sglang#36708): materialize the deferred `hc_post`, average the streams.
- `docker/patch_v11_dflash_kv_groups.py` + `Dockerfile.sm121-v11`: the bespoke GLM-5-Next KV grouping rejected the draft's sliding-window specs and fell into a generic path that cannot unify the DSA indexer's 33 B/token page. Adds a dedicated draft KV group at a quarter of the attention block size (block-id burn vs tensor-bytes tradeoff).
- `run.sh`: DFlash2-5 default (`SPEC=mtp` reverts), 327680 context, CUDA graphs default (`ENFORCE_EAGER=1` reverts), `EXTRA_ARGS` passthrough, draft-weight handling, and a fix for bash truncating brace-containing `${VAR:-...}` defaults.
- `bench_decode.py`: prose + structured phases (structured is the count-1-to-200 high-acceptance protocol the EXL3 recipe benches), spec-decode acceptance length per concurrency block from `/metrics`; survives individual stream failures. Parsing/stats offline-tested against a fake SSE server before use.
- `README.md`: measured numbers for both phases and both execution modes, tuning rationale, and the draft model's CC BY-NC-ND 4.0 license note.

## Verified numbers (2x DGX Spark, TP=2, 3-run medians, greedy, 200 tok, 327680 ctx)

CUDA graphs is the new default; eager measured the same day on the same boot pair.

| Phase | c | Graphs (default) | Eager | Acceptance len (of 6) |
|---|---|---:|---:|---:|
| prose | 1 | 28.2 | 27.6 | 2.95 |
| prose | 2 | 21.1 (agg 42.4) | 20.0 (40.1) | 2.94 |
| prose | 4 | 17.1 (agg 66.9) | 17.1 (66.8) | 3.03 |
| structured | 1 | 51.4 | 49.6 | 5.41 |
| structured | 2 | 41.5 (agg 81.8) | 41.8 (82.6) | 5.47 |
| structured | 4 | 35.7 (agg 142.7) | 35.0 (138.9) | 5.46 |

Draft acceptance rate ~0.40 prose, ~0.89 structured. Graphs numbers held across two full benches (second: prose 28.3/21.8/17.1, structured 51.2/40.8/35.5).

## CUDA graphs finding

Graphs were held off on sm_121 since the v8 image (PDL is gated off there because it races KDA state kernels; graphs themselves were unvalidated). Measured now: with capture sizes [1,2,4,6,12,18,24] the engine resolves FULL_AND_PIECEWISE, captures 4 uniform-decode graphs at the 6/12/18/24-token verify shapes (num_spec+1 x seqs) in 27 s with no measurable memory cost; KV pool stays 400,497 tokens. Greedy stayed lossless: a c=4 counting probe decoded 100+ exact sequential tokens per stream through graph replay, and the only eager-vs-graphs text divergence was a near-tie token (physics/science, 0.125-nat margin) that flips run-to-run within a single boot in either mode. Net +2-5% at c=1/2, flat at c=4, no stability regressions.

Tried and rejected: nothing this round; k=7 under graphs was considered and declined without a boot because positions 5-6 accept <15% (a drafter/target property graphs cannot change) and the per-sequence KDA state copies that starve c=4 admission at k=7 are likewise execution-mode independent.

## Load-bearing constraints (all measured)

`num_speculative_tokens=5` beats 7 (positions 5-6 accept <15% and each slot costs a per-sequence KDA state copy); the 4.14 GiB KV pin must stay (5.0 GiB slows decode 20-30% under UMA pressure and wedged the host under benchmark load; 5.14 GiB crashes); KV pool 400,497 tokens (1.22x at 327680); a 318k-token prompt prefills in 4m05s and answers correctly.

## Future work (documented, not implemented)

Draft-KV slot-sharing of MLA pages, the EXL3 recipe's approach: their drafter SWA slot-shares the target's MLA pages, freeing the draft's pool cost entirely and enabling much larger context. Our v11 layer instead gives the draft a dedicated KV group with its own tensors (`docker/patch_v11_dflash_kv_groups.py`). Porting slot-sharing onto the GLM5 bespoke KV layout would reclaim that pool share and is the next capacity lever.