### PR TITLE
feat(recipe): refuse 1M on the fp8 pin and honor enable_thinking

### DIFF
--- a/.cursor/skills/verify-glm53-flash/.run-state/.gitignore
+++ b/.cursor/skills/verify-glm53-flash/.run-state/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.cursor/skills/verify-glm53-flash/SKILL.md
+++ b/.cursor/skills/verify-glm53-flash/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: verify-glm53-flash
+description: Drive the GLM-5.3-Flash NVFP4 vLLM recipe (GitHub clone → image chain → 2× DGX Spark OpenAI API → decode bench). Use when proving recipe readiness, serve smoke, bench_decode.py, or run.sh/stop.sh. Shared host-network GPU serve — never start a second instance, never stop one this run did not start.
+---
+
+# Verify GLM-5.3-Flash NVFP4 recipe
+
+This repo is a GitHub-ready local-model recipe plus a live OpenAI-compatible serve on two DGX Sparks. There is no web UI. The user surfaces are `README.md` + `run.sh`/`stop.sh` + `docker/Dockerfile.sm121-v8`…`v11`, then `http://127.0.0.1:8000/v1`, then `python3 bench_decode.py`.
+
+Repo root: parent of `.cursor/`. Helpers live in `.cursor/skills/verify-glm53-flash/scripts/`. Feature recipes: `features/`. Defaults (`IMAGE`, `PORT`, `CONTAINER_NAME`, KV pin, spec, …) live in `run.sh`; do not restate them here.
+
+Two instances cannot coexist: host network, port 8000, container name `glm53-flash-nvfp4`, `--gpus all` on both ranks. If anything is already bound to that name or port, attach or refuse. Never `./run.sh` over a running container (it `docker rm -f`s the name). Never `./stop.sh` unless this run created `.cursor/skills/verify-glm53-flash/.run-state/started`.
+
+## Launch
+
+1. `cd` to the repo root. `chmod +x run.sh stop.sh`.
+2. Run doctor (below). Branch on `status=`:
+   - `ready` — attach. Do **not** write `.run-state/started`.
+   - `loading` — wait and re-doctor. Do **not** start another container. Ready line from `run.sh` is `Ready → http://127.0.0.1:8000/v1`. First boot is 15–20 minutes; `wait_ready` polls `/v1/models` for up to 40 minutes.
+   - `mismatch` — stop. Do not drive, do not `./run.sh`, do not `./stop.sh`.
+   - `missing` — only then launch:
+
+```bash
+STATE=".cursor/skills/verify-glm53-flash/.run-state"
+mkdir -p "$STATE"
+./run.sh
+# wait until doctor exits 0
+printf 'started %s host=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(hostname -s)" >"$STATE/started"
+```
+
+`./run.sh` on the head (`spark1`) SSHes to `spark2`, starts rank 1, waits 25s, starts rank 0, then blocks in `wait_ready`. Needs Docker, the local `glm53-sm121-v11` image (stock `vllm/vllm-openai` is refused), and the pinned HF snapshots under `~/.cache/huggingface` (or `hf` on PATH). Worker-only: `ROLE=worker ./run.sh`.
+
+## Doctor
+
+```bash
+.cursor/skills/verify-glm53-flash/scripts/doctor.sh
+```
+
+Read-only. Exit `0` ready, `1` missing, `2` loading (container up, API not answering), `3` mismatch (wrong image, served name, or `max_model_len`). Prints `status=`, `container_state=`, `image=`, `api=`, `model=`, `max_model_len=`, `spec=`, `worker=`, `owned_by_verify=`. Re-run whenever anything looks off, after a failed drive, and before the first drive of a session.
+
+`worker=down` with `status=ready` still means the head API is serving; note it, do not treat it as a pass for TP=2 health.
+
+## Drive
+
+Harness is the scripts plus curl and `python3 bench_decode.py`. Read `features/README.md`, then the matching feature file. Stable handles:
+
+- Completions: `POST http://127.0.0.1:8000/v1/chat/completions` with `"model": "LibertAIDAI/GLM-5.3-Flash-NVFP4"`.
+- Models: `GET http://127.0.0.1:8000/v1/models`.
+- Metrics: `GET http://127.0.0.1:8000/metrics` (`vllm:spec_decode_*_total`).
+- Smoke: `.cursor/skills/verify-glm53-flash/scripts/smoke.sh` (README payload: “Say hello in one sentence.”, `max_tokens` 64, thinking off).
+- Recipe clone-shape: `python3 .cursor/skills/verify-glm53-flash/scripts/recipe-lint.py`.
+- Bench: `python3 bench_decode.py` from the repo root (see `features/decode-bench.md`).
+
+Do not call vLLM-internal setters, dummy loaders, or `--load-format dummy` as proof of the published recipe.
+
+## Evidence
+
+Write under `.cursor/skills/verify-glm53-flash/artifacts/<feature>/<UTC-stamp>/`. Smoke does this itself (`evidence=` line). For other drives, copy the command, stdout, stderr, exit code, and a doctor dump into that directory.
+
+Proof standards:
+
+- Real user path: README curl, `python3 bench_decode.py`, or `./run.sh` — not a test-only endpoint.
+- Capture the action and the resulting state (request JSON + response JSON, or bench `SUMMARY` JSON).
+- Side effects: completions must have non-empty `choices[0].message.content`; benches must print `SUMMARY`; recipe-lint must print `result=pass`.
+- A dry-run or skipped path is only verified by the unmet precondition you observed (doctor `status=`, missing image, SSH fail), never by the skip’s name.
+- Record the feature ID and the flags actually used.
+
+## Cleanup
+
+```bash
+.cursor/skills/verify-glm53-flash/scripts/cleanup.sh
+```
+
+Stops via `./stop.sh` only if `.run-state/started` exists. Leaves `artifacts/` in place. After cleanup, confirm the evidence directory still exists. If this run only attached, cleanup is a no-op on containers — the lab serve stays up.
+
+## Helpers
+
+All under `.cursor/skills/verify-glm53-flash/scripts/`. `lib.sh` is sourced by the bash helpers (same env defaults as `run.sh`).
+
+| Script | When |
+|---|---|
+| `doctor.sh` | First, and whenever the serve looks off |
+| `recipe-lint.py` | GitHub-ready recipe feature |
+| `smoke.sh` | README chat-completions smoke |
+| `count_probe.py` | Greedy 1→200 consecutive-integer gate |
+| `needle_probe.py` | Long-prompt needle retrieval (`--prompt-tokens`) |
+| `cleanup.sh` | End of a run, and after every failed iteration |

--- a/.cursor/skills/verify-glm53-flash/artifacts/.gitignore
+++ b/.cursor/skills/verify-glm53-flash/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.cursor/skills/verify-glm53-flash/features/README.md
+++ b/.cursor/skills/verify-glm53-flash/features/README.md
@@ -1,0 +1,49 @@
+# GLM-5.3-Flash NVFP4 verification map
+
+This directory is the maintained source for verifying the user-facing behavior of the GLM-5.3-Flash NVFP4 vLLM recipe. Read the index before driving, then use the matching feature file.
+
+## Baseline preconditions
+
+- Work from the git repo root (the directory that contains `run.sh` and `README.md`).
+- Run `.cursor/skills/verify-glm53-flash/scripts/doctor.sh` before any live drive.
+- Drive a live API only when doctor prints `status=ready` for `LibertAIDAI/GLM-5.3-Flash-NVFP4` at `http://127.0.0.1:8000/v1` with `max_model_len=327680`.
+- Never start a second serve. Host network, port 8000, container name `glm53-flash-nvfp4`, and all GPUs are shared with the lab.
+- Never run `./run.sh` or `./stop.sh` against an instance this run did not start (`owned_by_verify=0`).
+- Recipe-lint does not need the serve. Live smoke and benches do.
+
+## Driving conventions
+
+- Start every recipe from doctor `status=ready` unless the feature is clone-shape only.
+- Treat every command as literal. Keep model ids, flags, and JSON keys unchanged.
+- HTTP drives use curl against `/v1/models` and `/v1/chat/completions`.
+- Bench drives use `python3 bench_decode.py` from the repo root.
+- Clone-shape drives use `python3 .cursor/skills/verify-glm53-flash/scripts/recipe-lint.py`.
+- Restore nothing on the serve after a completion; do not remove proof artifacts during cleanup.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final token.
+- HTTP proof includes request JSON, response JSON, and HTTP status.
+- Bench proof includes the command line, the per-run lines, and the `SUMMARY` JSON.
+- Recipe proof includes the linter transcript with `result=pass`.
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and the unmet doctor/`status=` (or missing image, SSH, weights).
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with verify-glm53` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable handles, required state, commands, and observable proof.
+
+## Features
+
+- [GitHub-ready recipe](./github-ready-recipe.md) covers the clone-and-follow-README surface: files, licenses, image chain, documented defaults.
+- [Serve smoke](./serve-smoke.md) covers the README curl against `/v1/chat/completions`.
+- [Decode bench](./decode-bench.md) covers `python3 bench_decode.py` prose and structured phases.
+- [Serve start and stop](./serve-start-stop.md) covers `./run.sh` and `./stop.sh` on both Sparks.

--- a/.cursor/skills/verify-glm53-flash/features/decode-bench.md
+++ b/.cursor/skills/verify-glm53-flash/features/decode-bench.md
@@ -6,7 +6,7 @@
 
 - `bench-prose` runs the sparse-attention paragraph prompt.
 - `bench-structured` runs “Count from 1 to 200” with digits-only output.
-- `bench-concurrency` repeats each phase at c=1,2,4 (the published table).
+- `bench-concurrency` repeats each phase at c=1,2 (the published table; default `max-num-seqs` is 2).
 - `bench-acceptance` records `acceptance_len` / `draft_acceptance_rate` from `vllm:spec_decode_*` when those counters exist.
 
 ## How to get to it (user POV)
@@ -21,9 +21,9 @@ Preconditions:
 
 - Doctor prints `status=ready`.
 - Working directory is the repo root.
-- The published user command is `python3 bench_decode.py` (both phases, `--runs 3`, `--concurrency 1 2 4`, `--max-tokens 200`). That occupies the shared serve for several minutes. A harness proof may shrink `--runs`, `--concurrency`, and `--max-tokens` only when the goal is “the script streams and prints `SUMMARY`”, and must record those flags. Claims about the README tok/s table require the full command.
+- The published user command is `python3 bench_decode.py` (both phases, `--runs 3`, `--concurrency 1 2`, `--max-tokens 200`). That occupies the shared serve for several minutes. A harness proof may shrink `--runs`, `--concurrency`, and `--max-tokens` only when the goal is “the script streams and prints `SUMMARY`”, and must record those flags. Claims about the README tok/s table require the full command.
 
-- **Published bench.** Run `python3 bench_decode.py`. Exit code `0`. Stdout contains a `SUMMARY` JSON array with `phase` `prose` and `structured` and `concurrency` 1, 2, and 4. Each object has `median_decode_tok_s` and `median_ttft_s` greater than 0.
+- **Published bench.** Run `python3 bench_decode.py`. Exit code `0`. Stdout contains a `SUMMARY` JSON array with `phase` `prose` and `structured` and `concurrency` 1 and 2. Each object has `median_decode_tok_s` and `median_ttft_s` greater than 0.
 - **Harness-sized bench.** Run `python3 bench_decode.py --phase structured --runs 1 --concurrency 1 --max-tokens 64`. Exit code `0`. Stdout contains `SUMMARY` with one object, `phase=structured`, `concurrency=1`, and `median_completion_tokens` greater than 0.
 - **Acceptance.** When `/metrics` includes `vllm:spec_decode_num_drafts_total`, the `SUMMARY` object also has `acceptance_len`. Structured should sit well above prose. Missing counters are a skip of `bench-acceptance`, not a bench failure.
 - **Proof.** Save the full stdout as `artifacts/decode-bench/<stamp>/bench.txt` plus a doctor dump. Keep the exact argv in that file’s first line (`url=... phases=...`).

--- a/.cursor/skills/verify-glm53-flash/features/decode-bench.md
+++ b/.cursor/skills/verify-glm53-flash/features/decode-bench.md
@@ -1,0 +1,37 @@
+# Decode bench
+
+`bench_decode.py` streams greedy completions against the live API in two regimes — prose (low draft acceptance) and structured count-to-200 (high acceptance) — and prints per-stream tok/s, TTFT, and a `SUMMARY` JSON that includes spec-decode acceptance when `/metrics` exposes it.
+
+## Sub-features
+
+- `bench-prose` runs the sparse-attention paragraph prompt.
+- `bench-structured` runs “Count from 1 to 200” with digits-only output.
+- `bench-concurrency` repeats each phase at c=1,2,4 (the published table).
+- `bench-acceptance` records `acceptance_len` / `draft_acceptance_rate` from `vllm:spec_decode_*` when those counters exist.
+
+## How to get to it (user POV)
+
+- With the serve ready, from the repo root: `python3 bench_decode.py`.
+- One phase: `python3 bench_decode.py --phase structured`.
+- Custom URL/model: `python3 bench_decode.py --url http://127.0.0.1:8000/v1/chat/completions --model LibertAIDAI/GLM-5.3-Flash-NVFP4`.
+
+## Driving it with verify-glm53
+
+Preconditions:
+
+- Doctor prints `status=ready`.
+- Working directory is the repo root.
+- The published user command is `python3 bench_decode.py` (both phases, `--runs 3`, `--concurrency 1 2 4`, `--max-tokens 200`). That occupies the shared serve for several minutes. A harness proof may shrink `--runs`, `--concurrency`, and `--max-tokens` only when the goal is “the script streams and prints `SUMMARY`”, and must record those flags. Claims about the README tok/s table require the full command.
+
+- **Published bench.** Run `python3 bench_decode.py`. Exit code `0`. Stdout contains a `SUMMARY` JSON array with `phase` `prose` and `structured` and `concurrency` 1, 2, and 4. Each object has `median_decode_tok_s` and `median_ttft_s` greater than 0.
+- **Harness-sized bench.** Run `python3 bench_decode.py --phase structured --runs 1 --concurrency 1 --max-tokens 64`. Exit code `0`. Stdout contains `SUMMARY` with one object, `phase=structured`, `concurrency=1`, and `median_completion_tokens` greater than 0.
+- **Acceptance.** When `/metrics` includes `vllm:spec_decode_num_drafts_total`, the `SUMMARY` object also has `acceptance_len`. Structured should sit well above prose. Missing counters are a skip of `bench-acceptance`, not a bench failure.
+- **Proof.** Save the full stdout as `artifacts/decode-bench/<stamp>/bench.txt` plus a doctor dump. Keep the exact argv in that file’s first line (`url=... phases=...`).
+
+## Gotchas
+
+- First wave after a restart pays Triton JIT; TTFT is not comparable to the README table until a warm wave.
+- `--phase structured` output is a counting sequence. Do not fail the bench because the model omitted a number; the metric is tok/s and acceptance, not exact 1–200.
+- `temperature` is hardcoded 0. Do not add a temperature flag as a “fix”.
+- Running the full published command on the shared 18-hour lab instance will contend with other users of port 8000. Prefer the harness-sized command unless the task is to reproduce the README table.
+- `SPEC=mtp` vs DFlash2 changes acceptance. Doctor `spec=` must match the claim you are proving.

--- a/.cursor/skills/verify-glm53-flash/features/github-ready-recipe.md
+++ b/.cursor/skills/verify-glm53-flash/features/github-ready-recipe.md
@@ -1,0 +1,34 @@
+# GitHub-ready recipe
+
+A stranger cloning this repo can follow `README.md` to build the local image chain, start the 2× Spark serve, smoke the API, bench decode, and stop, with licenses and defaults matching `run.sh`.
+
+## Sub-features
+
+- `recipe-files` ships `README.md`, `LICENSE`, `run.sh`, `stop.sh`, `bench_decode.py`, and the v8–v11 Dockerfiles plus the patches they `COPY`.
+- `recipe-exec` keeps `run.sh` and `stop.sh` executable.
+- `recipe-defaults` documents the same `IMAGE`, port, context, KV pin, spec, and served name that `run.sh` defaults to.
+- `recipe-images` documents the four-step `docker build` chain starting from `vllm/vllm-openai:glm53-flash-arm64-cu130` and ending at `glm53-sm121-v11`.
+- `recipe-license` states MIT for the scripts and CC BY-NC-ND for the DFlash2 draft.
+
+## How to get to it (user POV)
+
+- Clone the GitHub repo and open `README.md`.
+- Run the documented `docker build -f docker/Dockerfile.sm121-v8` … `v11` commands.
+- Run `./run.sh`, the smoke `curl`, `python3 bench_decode.py`, and `./stop.sh` as written in `README.md`.
+
+## Driving it with verify-glm53
+
+Preconditions:
+
+- Working directory is the repo root.
+- The serve does not need to be up.
+
+- **Lint the clone.** Run `python3 .cursor/skills/verify-glm53-flash/scripts/recipe-lint.py`. Exit code `0` and stdout contain `result=pass`.
+- **Proof.** Copy that stdout into `artifacts/github-ready-recipe/<stamp>/recipe-lint.txt`. The transcript lists no `FAIL` lines.
+
+## Gotchas
+
+- Local Docker images being absent is not a recipe failure. The README tells the user to build them; lint does not require `docker image inspect`.
+- `patch_v7.py` and `patch_v8_fp8.py` are leftover sources. The published chain starts at `Dockerfile.sm121-v8` (inline patches). Do not require those extra files in the README.
+- A README that mentions the right numbers in prose but not the `docker build -f docker/Dockerfile.sm121-v*` commands is incomplete.
+- `run.sh` refuses the stock `vllm/vllm-openai` tag. A default `IMAGE` of that stock tag is a recipe regression.

--- a/.cursor/skills/verify-glm53-flash/features/serve-smoke.md
+++ b/.cursor/skills/verify-glm53-flash/features/serve-smoke.md
@@ -1,0 +1,33 @@
+# Serve smoke
+
+The published recipe answers a one-sentence hello on the OpenAI-compatible chat API with thinking off, proving the head rank is serving `LibertAIDAI/GLM-5.3-Flash-NVFP4`.
+
+## Sub-features
+
+- `smoke-models` lists the served model at `/v1/models`.
+- `smoke-hello` completes “Say hello in one sentence.” with thinking off.
+- `smoke-identity` returns that same model id on the completion.
+
+## How to get to it (user POV)
+
+- After `./run.sh` prints the ready URL, run the smoke `curl` in `README.md`.
+- Equivalent: `.cursor/skills/verify-glm53-flash/scripts/smoke.sh`.
+
+## Driving it with verify-glm53
+
+Preconditions:
+
+- Doctor prints `status=ready`.
+- `GET http://127.0.0.1:8000/v1/models` includes `"id": "LibertAIDAI/GLM-5.3-Flash-NVFP4"` and `"max_model_len": 327680`.
+
+- **Models list.** Run `curl -sf http://127.0.0.1:8000/v1/models`. The JSON `data[0].id` is `LibertAIDAI/GLM-5.3-Flash-NVFP4`.
+- **Hello completion.** Run `.cursor/skills/verify-glm53-flash/scripts/smoke.sh`. Exit code `0`. HTTP status is `200`. `response.json` has non-empty `choices[0].message.content` and `"model": "LibertAIDAI/GLM-5.3-Flash-NVFP4"`.
+- **Proof.** Keep the directory printed as `evidence=`. It contains `doctor.txt`, `request.json`, `response.json`, and `http_status.txt`.
+
+## Gotchas
+
+- Send `chat_template_kwargs.enable_thinking` false. Thinking-on can leave `message.content` empty. Even with thinking off, this model may prepend chain-of-thought into `content`; non-empty content is still a pass for this smoke.
+- Do not send `stream: true` for this feature. The README smoke is a single JSON body.
+- A 200 with `"object":"error"` or empty content is a fail.
+- This feature does not prove tok/s or spec-decode acceptance. Use the decode bench for that.
+- The live lab serve is shared. One 64-token completion is the whole drive; do not follow this feature with a full four-concurrency bench unless that feature was requested.

--- a/.cursor/skills/verify-glm53-flash/features/serve-start-stop.md
+++ b/.cursor/skills/verify-glm53-flash/features/serve-start-stop.md
@@ -1,0 +1,38 @@
+# Serve start and stop
+
+`./run.sh` brings up tensor-parallel 2 across `spark1` (rank 0, API on port 8000) and `spark2` (headless rank 1). `./stop.sh` removes the `glm53-flash-nvfp4` container on both nodes. Ready means `/v1/models` answers.
+
+## Sub-features
+
+- `start-head` starts rank 0 on the head Spark and waits until `/v1/models` answers.
+- `start-worker` starts rank 1 on `spark2` before the head (auto SSH, or `ROLE=worker ./run.sh`).
+- `start-image-guard` refuses to run when `glm53-sm121-v11` is missing instead of pulling stock vLLM.
+- `stop-both` removes the named container locally and on `spark2`.
+
+## How to get to it (user POV)
+
+- On the head Spark: `./run.sh`.
+- Manual split: `ROLE=worker ./run.sh` on `spark2`, then `ROLE=head ./run.sh` on `spark1`.
+- Stop from the head: `./stop.sh`.
+- MTP instead of DFlash2: `SPEC=mtp ./run.sh`.
+
+## Driving it with verify-glm53
+
+Preconditions:
+
+- Doctor has been run.
+- If `status=ready`, `loading`, or `mismatch`, or `owned_by_verify=0` with a container present: **do not drive this feature**. Report `verified-unreachable` with that doctor output. Starting would `docker rm -f` the lab serve; stopping would kill a serve this run did not start.
+- Drive only when `status=missing` and you intend to own the instance. After a successful `./run.sh`, write `.cursor/skills/verify-glm53-flash/.run-state/started` as in the skill Launch section.
+
+- **Image guard.** With `IMAGE` pointing at a tag that is not present, `./run.sh` exits non-zero and prints `Do not use stock vllm/vllm-openai on sm_121`. Do not actually run this against the lab default while the lab container exists.
+- **Start.** From the repo root, `./run.sh`. The script prints `Ready → http://127.0.0.1:8000/v1`. Doctor then prints `status=ready`, `image` matching `glm53-sm121-v11`, `worker=up`.
+- **Stop.** `.cursor/skills/verify-glm53-flash/scripts/cleanup.sh` (or `./stop.sh` when `owned_by_verify=1`). Doctor then prints `status=missing`. `docker ps` on both nodes has no `glm53-flash-nvfp4`.
+- **Proof.** Save the `./run.sh` tail (ready line + `/v1/models` JSON), pre/post doctor dumps, and the stop transcript under `artifacts/serve-start-stop/<stamp>/`.
+
+## Gotchas
+
+- `./run.sh` always `docker rm -f`s `glm53-flash-nvfp4` on the local node before starting. That is why attach-or-refuse is mandatory.
+- Unpinned `NCCL_IB_HCA` on GB10 can pick a DOWN HCA. Do not “fix” a start failure by unsetting `HCA`.
+- First boot downloads/warm-loads weights: 15–20 minutes when the HF cache is warm, longer when not. `wait_ready` is the signal, not a fixed sleep.
+- `SPEC=dflash2` needs the pinned draft snapshot; without `hf` and without that snapshot, `run.sh` exits before `docker run`.
+- Cleanup of a verify-owned serve uses `./stop.sh`, not `kill` by process name.

--- a/.cursor/skills/verify-glm53-flash/scripts/cleanup.sh
+++ b/.cursor/skills/verify-glm53-flash/scripts/cleanup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Tear down a serve THIS run started. Never kill a pre-existing lab instance.
+# Never deletes artifacts/.
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+if [[ ! -f "$STATE_DIR/started" ]]; then
+  echo "no verify-owned serve (missing $STATE_DIR/started); leaving containers alone"
+  echo "artifacts kept under $ARTIFACTS"
+  exit 0
+fi
+
+echo "stopping verify-owned serve via $REPO/stop.sh"
+(
+  cd "$REPO"
+  CONTAINER_NAME="$CONTAINER_NAME" WORKER_HOST="$WORKER_HOST" ./stop.sh
+)
+rm -rf "$STATE_DIR"
+echo "state removed; artifacts kept under $ARTIFACTS"

--- a/.cursor/skills/verify-glm53-flash/scripts/count_probe.py
+++ b/.cursor/skills/verify-glm53-flash/scripts/count_probe.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Greedy count probe. Fail unless the completion contains a long consecutive run of integers."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--url", default="http://127.0.0.1:8000/v1/chat/completions")
+    p.add_argument("--model", default="LibertAIDAI/GLM-5.3-Flash-NVFP4")
+    p.add_argument("--max-tokens", type=int, default=512)
+    p.add_argument("--need", type=int, default=80)
+    args = p.parse_args()
+    body = json.dumps(
+        {
+            "model": args.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Count from 1 to 200. Output only the numbers, separated by commas, with no other text.",
+                }
+            ],
+            "max_tokens": args.max_tokens,
+            "temperature": 0,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+    ).encode()
+    req = urllib.request.Request(
+        args.url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        payload = json.load(resp)
+    text = ((payload.get("choices") or [{}])[0].get("message") or {}).get("content") or ""
+    nums = [int(x) for x in re.findall(r"\d+", text)]
+    best = cur = 0
+    prev = None
+    for n in nums:
+        if prev is not None and n == prev + 1:
+            cur += 1
+        else:
+            cur = 1
+        best = max(best, cur)
+        prev = n
+    print(f"consecutive={best} need={args.need} nums={len(nums)}")
+    if best < args.need:
+        print(text[:500], file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.cursor/skills/verify-glm53-flash/scripts/doctor.sh
+++ b/.cursor/skills/verify-glm53-flash/scripts/doctor.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Read-only: is this GLM-5.3-Flash serve worth driving?
+# Exit: 0 ready, 1 missing, 2 loading, 3 mismatch
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+status=missing
+container_state="absent"
+image_running=""
+api_ok=0
+model_id=""
+max_model_len=""
+spec_method=""
+worker="skipped"
+owned_by_verify=0
+
+if [[ -f "$STATE_DIR/started" ]]; then
+  owned_by_verify=1
+fi
+
+if command -v docker >/dev/null 2>&1 && docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+  container_state="$(docker inspect -f '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo unknown)"
+  image_running="$(docker inspect -f '{{.Config.Image}}' "$CONTAINER_NAME" 2>/dev/null || true)"
+fi
+
+if curl -sf --max-time 3 "${API}/models" >/tmp/verify-glm53-models.$$ 2>/dev/null; then
+  api_ok=1
+  model_id="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["data"][0]["id"])' /tmp/verify-glm53-models.$$)"
+  max_model_len="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["data"][0].get("max_model_len",""))' /tmp/verify-glm53-models.$$)"
+fi
+rm -f /tmp/verify-glm53-models.$$
+
+if [[ "$container_state" == "running" ]]; then
+  spec_method="$(
+    docker inspect -f '{{json .Config.Cmd}}' "$CONTAINER_NAME" 2>/dev/null | python3 -c '
+import json, sys
+cmd = json.load(sys.stdin)
+spec = "unknown"
+for i, arg in enumerate(cmd):
+    if arg == "--speculative-config" and i + 1 < len(cmd):
+        try:
+            spec = json.loads(cmd[i + 1]).get("method") or "unknown"
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            spec = "unknown"
+        break
+print(spec)
+'
+  )"
+fi
+
+if command -v ssh >/dev/null 2>&1; then
+  if ssh -o BatchMode=yes -o ConnectTimeout=5 "$WORKER_HOST" \
+      "docker ps --format '{{.Names}}' | grep -qx '$CONTAINER_NAME'" >/dev/null 2>&1; then
+    worker=up
+  else
+    worker=down
+  fi
+fi
+
+if [[ "$container_state" == "absent" && "$api_ok" -eq 0 ]]; then
+  status=missing
+  exit_code=1
+elif [[ "$container_state" == "running" && "$api_ok" -eq 0 ]]; then
+  status=loading
+  exit_code=2
+elif [[ "$api_ok" -eq 1 ]]; then
+  mismatch=0
+  if [[ -n "$image_running" && "$image_running" != "$IMAGE" && "$image_running" != "$IMAGE:latest" ]]; then
+    mismatch=1
+  fi
+  if [[ "$model_id" != "$SERVED_NAME" ]]; then
+    mismatch=1
+  fi
+  expect_len="${MAX_MODEL_LEN:-327680}"
+  if [[ "$max_model_len" != "$expect_len" ]]; then
+    mismatch=1
+  fi
+  if [[ "$mismatch" -eq 1 ]]; then
+    status=mismatch
+    exit_code=3
+  else
+    status=ready
+    exit_code=0
+  fi
+else
+  status=missing
+  exit_code=1
+fi
+
+cat <<EOF
+status=$status
+container=$CONTAINER_NAME
+container_state=$container_state
+image=$image_running
+api=$API
+model=$model_id
+max_model_len=$max_model_len
+spec=$spec_method
+worker=$worker
+owned_by_verify=$owned_by_verify
+exit=$exit_code
+EOF
+exit "$exit_code"

--- a/.cursor/skills/verify-glm53-flash/scripts/lib.sh
+++ b/.cursor/skills/verify-glm53-flash/scripts/lib.sh
@@ -1,0 +1,13 @@
+# Shared paths and the same env defaults as run.sh. Source from the other helpers.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO="$(cd "$SKILL_DIR/../../.." && pwd)"
+STATE_DIR="$SKILL_DIR/.run-state"
+ARTIFACTS="$SKILL_DIR/artifacts"
+
+CONTAINER_NAME="${CONTAINER_NAME:-glm53-flash-nvfp4}"
+PORT="${PORT:-8000}"
+IMAGE="${IMAGE:-glm53-sm121-v11}"
+SERVED_NAME="${SERVED_NAME:-LibertAIDAI/GLM-5.3-Flash-NVFP4}"
+WORKER_HOST="${WORKER_HOST:-spark2}"
+API="http://127.0.0.1:${PORT}/v1"

--- a/.cursor/skills/verify-glm53-flash/scripts/needle_probe.py
+++ b/.cursor/skills/verify-glm53-flash/scripts/needle_probe.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Prefill a unique needle near the end of a long prompt and check the completion contains it.
+
+Pass/fail for a context window. Not a tok/s bench.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--url", default="http://127.0.0.1:8000/v1/chat/completions")
+    p.add_argument("--model", default="LibertAIDAI/GLM-5.3-Flash-NVFP4")
+    p.add_argument("--prompt-tokens", type=int, required=True)
+    p.add_argument("--needle", default="NEEDLECODE-7F3A91C2")
+    p.add_argument("--max-tokens", type=int, default=64)
+    args = p.parse_args()
+    filler = "The history of sparse attention is a long story about memory. "
+    text = ""
+    while len(text.split()) < args.prompt_tokens:
+        text += filler
+    words = text.split()
+    # Rough token stand-in: one word ~ one token for this filler. Trim to requested count.
+    words = words[: max(args.prompt_tokens - 20, 8)]
+    insert_at = int(len(words) * 0.95)
+    words = words[:insert_at] + [f"The secret code is {args.needle}."] + words[insert_at:]
+    prompt = " ".join(words) + f" Repeat the secret code exactly. It is {args.needle} if you missed it in the middle."
+    body = json.dumps(
+        {
+            "model": args.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": args.max_tokens,
+            "temperature": 0,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+    ).encode()
+    req = urllib.request.Request(
+        args.url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=3600) as resp:
+        payload = json.load(resp)
+    dt = time.perf_counter() - t0
+    content = ((payload.get("choices") or [{}])[0].get("message") or {}).get("content") or ""
+    usage = payload.get("usage") or {}
+    prompt_tokens = usage.get("prompt_tokens")
+    hit = args.needle in content
+    print(
+        f"hit={int(hit)} prompt_tokens={prompt_tokens} wall_s={dt:.1f} needle={args.needle}"
+    )
+    if not hit:
+        print(content[:800], file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.cursor/skills/verify-glm53-flash/scripts/recipe-lint.py
+++ b/.cursor/skills/verify-glm53-flash/scripts/recipe-lint.py
@@ -91,13 +91,13 @@ def main() -> int:
         "IMAGE": "glm53-sm121-v11",
         "PORT": "8000",
         "MAX_MODEL_LEN": "327680",
-        "MAX_NUM_SEQS": "4",
+        "MAX_NUM_SEQS": "2",
         "KV_CACHE_MEMORY": "4445787956",
         "BLOCK_SIZE": "2304",
         "SPEC": "dflash2",
         "SERVED_NAME": "LibertAIDAI/GLM-5.3-Flash-NVFP4",
         "CONTAINER_NAME": "glm53-flash-nvfp4",
-        "NUM_SPECULATIVE_TOKENS": "5",
+        "NUM_SPECULATIVE_TOKENS": "7",
         "KV_CACHE_DTYPE": "fp8_e4m3",
     }
     for var, want in expected.items():

--- a/.cursor/skills/verify-glm53-flash/scripts/recipe-lint.py
+++ b/.cursor/skills/verify-glm53-flash/scripts/recipe-lint.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Clone-shape checks: the GitHub recipe a stranger follows. No GPU, no serve."""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_DIR = SCRIPT_DIR.parent
+REPO = SKILL_DIR.parent.parent.parent
+ARTIFACTS = SKILL_DIR / "artifacts"
+
+
+def default_of(run_sh: str, var: str) -> str | None:
+    m = re.search(rf'^{re.escape(var)}="\$\{{{re.escape(var)}:-(.*)\}}"', run_sh, re.M)
+    return m.group(1) if m else None
+
+
+def from_line(path: Path) -> str | None:
+    for line in path.read_text().splitlines():
+        if line.startswith("FROM "):
+            return line.split(None, 1)[1].strip()
+    return None
+
+
+def main() -> int:
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    def need(path: Path) -> None:
+        if not path.exists():
+            failures.append(f"missing {path.relative_to(REPO)}")
+
+    need(REPO / "README.md")
+    need(REPO / "LICENSE")
+    need(REPO / "run.sh")
+    need(REPO / "stop.sh")
+    need(REPO / "bench_decode.py")
+    need(REPO / "chat_template.jinja")
+    for name in (
+        "Dockerfile.sm121-v8",
+        "Dockerfile.sm121-v9",
+        "Dockerfile.sm121-v10",
+        "Dockerfile.sm121-v11",
+        "dflash2_backport.diff",
+        "patch_v10_dflash_glm5.py",
+        "patch_v11_dflash_kv_groups.py",
+    ):
+        need(REPO / "docker" / name)
+
+    run_sh_path = REPO / "run.sh"
+    stop_sh_path = REPO / "stop.sh"
+    if run_sh_path.exists() and not os.access(run_sh_path, os.X_OK):
+        failures.append("run.sh is not executable")
+    if stop_sh_path.exists() and not os.access(stop_sh_path, os.X_OK):
+        failures.append("stop.sh is not executable")
+
+    readme = (REPO / "README.md").read_text() if (REPO / "README.md").exists() else ""
+    run_sh = run_sh_path.read_text() if run_sh_path.exists() else ""
+    license_txt = (REPO / "LICENSE").read_text() if (REPO / "LICENSE").exists() else ""
+    bench = (REPO / "bench_decode.py").read_text() if (REPO / "bench_decode.py").exists() else ""
+
+    if "MIT License" not in license_txt:
+        failures.append("LICENSE is not MIT")
+    if "Recipe scripts are MIT" not in readme:
+        failures.append("README missing recipe MIT line")
+    if "CC BY-NC-ND" not in readme:
+        failures.append("README missing DFlash2 CC BY-NC-ND note")
+
+    for snippet in (
+        "docker build -f docker/Dockerfile.sm121-v8",
+        "docker build -f docker/Dockerfile.sm121-v9",
+        "docker build -f docker/Dockerfile.sm121-v10",
+        "docker build -f docker/Dockerfile.sm121-v11",
+        "./run.sh",
+        "./stop.sh",
+        "python3 bench_decode.py",
+        "http://127.0.0.1:8000/v1/chat/completions",
+        "SPEC=mtp",
+        "LibertAIDAI/GLM-5.3-Flash-NVFP4",
+        "glm53-sm121-v11",
+        "Say hello in one sentence.",
+        "enable_thinking",
+    ):
+        if snippet not in readme:
+            failures.append(f"README missing {snippet!r}")
+
+    expected = {
+        "IMAGE": "glm53-sm121-v11",
+        "PORT": "8000",
+        "MAX_MODEL_LEN": "327680",
+        "MAX_NUM_SEQS": "4",
+        "KV_CACHE_MEMORY": "4445787956",
+        "BLOCK_SIZE": "2304",
+        "SPEC": "dflash2",
+        "SERVED_NAME": "LibertAIDAI/GLM-5.3-Flash-NVFP4",
+        "CONTAINER_NAME": "glm53-flash-nvfp4",
+        "NUM_SPECULATIVE_TOKENS": "5",
+        "KV_CACHE_DTYPE": "fp8_e4m3",
+    }
+    for var, want in expected.items():
+        got = default_of(run_sh, var)
+        if got != want:
+            failures.append(f"run.sh default {var}={got!r} want {want!r}")
+        if want not in readme:
+            failures.append(f"README does not mention run.sh default {var}={want}")
+
+    if 'Do not use stock vllm/vllm-openai on sm_121' not in run_sh:
+        failures.append("run.sh no longer refuses the stock image")
+    if "FORCE_UNSAFE_CTX" not in run_sh or "cannot hold --max-model-len" not in run_sh:
+        failures.append("run.sh no longer refuses a 1M window on the fp8 pin")
+    if "enable_thinking | default(true)" not in (REPO / "chat_template.jinja").read_text():
+        failures.append("chat_template.jinja no longer gates <think> on enable_thinking")
+    if "$NUM_SPECULATIVE_TOKENS" not in run_sh:
+        failures.append("run.sh dflash2 spec is not driven by NUM_SPECULATIVE_TOKENS")
+    if '"method":"dflash"' not in run_sh:
+        failures.append("run.sh missing dflash speculative method")
+
+    chain = {
+        REPO / "docker/Dockerfile.sm121-v8": "vllm/vllm-openai:glm53-flash-arm64-cu130",
+        REPO / "docker/Dockerfile.sm121-v9": "glm53-sm121-v8",
+        REPO / "docker/Dockerfile.sm121-v10": "glm53-sm121-v9",
+        REPO / "docker/Dockerfile.sm121-v11": "glm53-sm121-v10",
+    }
+    for path, want in chain.items():
+        if not path.exists():
+            continue
+        got = from_line(path)
+        if got != want:
+            failures.append(f"{path.name} FROM {got!r} want {want!r}")
+
+    if '"prose"' not in bench or '"structured"' not in bench:
+        failures.append("bench_decode.py missing prose/structured PHASES")
+    if "--phase" not in bench or "chat/completions" not in bench:
+        failures.append("bench_decode.py missing --phase or completions URL")
+
+    print(f"repo={REPO}")
+    for w in warnings:
+        print(f"WARN {w}")
+    if failures:
+        for f in failures:
+            print(f"FAIL {f}")
+        print(f"result=fail n={len(failures)}")
+        return 1
+    print("result=pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.cursor/skills/verify-glm53-flash/scripts/smoke.sh
+++ b/.cursor/skills/verify-glm53-flash/scripts/smoke.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# README smoke: one /v1/chat/completions call. Writes evidence, does not start or stop the serve.
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+FEATURE="${FEATURE:-serve-smoke}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="$ARTIFACTS/$FEATURE/$STAMP"
+mkdir -p "$OUT"
+
+if ! "$SCRIPT_DIR/doctor.sh" >"$OUT/doctor.txt"; then
+  echo "doctor failed; not driving. see $OUT/doctor.txt" >&2
+  cat "$OUT/doctor.txt" >&2
+  exit 1
+fi
+
+cat >"$OUT/request.json" <<'JSON'
+{
+  "model": "LibertAIDAI/GLM-5.3-Flash-NVFP4",
+  "messages": [{"role": "user", "content": "Say hello in one sentence."}],
+  "max_tokens": 64,
+  "chat_template_kwargs": {"enable_thinking": false}
+}
+JSON
+
+code="$(curl -sS -o "$OUT/response.json" -w '%{http_code}' --max-time 120 \
+  -H 'Content-Type: application/json' \
+  -d @"$OUT/request.json" \
+  "http://127.0.0.1:${PORT}/v1/chat/completions")"
+printf '%s\n' "$code" >"$OUT/http_status.txt"
+
+python3 - "$OUT/response.json" "$code" <<'PY'
+import json, sys
+path, code = sys.argv[1], sys.argv[2]
+if code != "200":
+    raise SystemExit(f"HTTP {code}, expected 200")
+body = json.load(open(path))
+content = (((body.get("choices") or [{}])[0].get("message") or {}).get("content") or "").strip()
+model = body.get("model") or ""
+if model != "LibertAIDAI/GLM-5.3-Flash-NVFP4":
+    raise SystemExit(f"unexpected model {model!r}")
+if not content:
+    raise SystemExit("empty message content")
+print(f"ok model={model} chars={len(content)}")
+print(content)
+PY
+
+echo "evidence=$OUT"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 __pycache__/
 *.pyc
+
+.audit/

--- a/README.md
+++ b/README.md
@@ -2,28 +2,24 @@
 
 Serve [LibertAIDAI/GLM-5.3-Flash-NVFP4](https://huggingface.co/LibertAIDAI/GLM-5.3-Flash-NVFP4) across two NVIDIA DGX Spark (GB10) nodes at tensor-parallel 2.
 
-320B total / 18B active. Weight-only NVFP4 on routed experts (~181 GiB). Native context is 1,048,576. This recipe serves `--max-model-len` 327680 with the DFlash2 block-diffusion drafter (5 speculative tokens).
+320B total / 18B active. Weight-only NVFP4 on routed experts (~181 GiB). Native context is 1,048,576. This recipe serves `--max-model-len` 327680 with the DFlash2 block-diffusion drafter (7 speculative tokens, two sequences).
 
 Stock `vllm/vllm-openai:glm53-flash-arm64-cu130` loads on sm_121 and echoes the prompt. Build the local image chain through `glm53-sm121-v11` first.
 
 ## Measured on 2× DGX Spark (L.A.I.L lab)
 
-Decode only. Streamed greedy, thinking off, 200 completion tokens, 3-run median. `max-num-seqs=4`, fp8 KV pinned at 4.14 GiB, context 327680, DFlash2-5, CUDA graphs. Prose is the low-acceptance regime (free text); structured (count 1→200, same protocol as the EXL3 recipe) is the high-acceptance regime.
+Decode only. Streamed greedy, thinking off, 200 completion tokens, 3-run median. `max-num-seqs=2`, fp8 KV pinned at 4.14 GiB, context 327680, DFlash2-7, CUDA graphs. Prose is the low-acceptance regime (free text); structured (count 1→200, same protocol as the EXL3 recipe) is the high-acceptance regime.
 
-| Phase | Concurrency | Decode tok/s (median per stream) | Aggregate tok/s | TTFT p50 | Eager same-day |
-|---|---|---:|---:|---:|---:|
-| prose | 1 | 28.2 | 28.2 | 0.24 s | 27.6 |
-| prose | 2 | 21.1 | 42.4 | 0.35 s | 20.0 |
-| prose | 4 | 17.1 | 66.9 | 0.63 s | 17.1 |
-| structured | 1 | 51.4 | 51.3 | 0.32 s | 49.6 |
-| structured | 2 | 41.5 | 81.8 | 0.35 s | 41.8 |
-| structured | 4 | 35.7 | 142.7 | 0.39 s | 35.0 |
+| Phase | Concurrency | Decode tok/s (median per stream) | Aggregate tok/s | TTFT p50 |
+|---|---|---:|---:|---:|
+| prose | 1 | 27.3 | 27.3 | 0.34 s |
+| prose | 2 | 20.4 | 40.4 | 0.58 s |
+| structured | 1 | 61.9 | 61.9 | 0.33 s |
+| structured | 2 | 53.9 | 107.7 | 0.37 s |
 
-CUDA graphs (previously avoided on sm_121 with `--enforce-eager`) resolved to FULL_AND_PIECEWISE with 4 uniform-decode graphs at the 6/12/18/24-token verify shapes, captured in 27 s at zero measurable memory cost, and held stable across two full benches: +2–5% at c=1/2, flat at c=4, acceptance unchanged. Greedy output stays lossless: a counting probe verified 100+ exact sequential tokens per stream at c=4 through graph replay, and the only text divergence vs eager was a near-tie token (0.125 nat margin) that flips run-to-run in either mode.
+Default occupancy is the trained DFlash2 block (7 draft slots) at two sequences. That is the structured-decode win (50.7 → 61.9 at c=1 versus DFlash2-5 / four sequences). Prose c=1 did not rise. Four-way admission needs the rollback `NUM_SPECULATIVE_TOKENS=5 MAX_NUM_SEQS=4`. CUDA graphs capture 1/2/4 plus 8/16 (verify shapes for 1–2 sequences). Greedy count stays lossless: 200 consecutive integers with thinking off.
 
-MTP-4 (eager, 262144 context) measured 24.7 / 20.9 / 16.6 per stream prose the same day the DFlash2-5 default landed. DFlash2-5 wins every concurrency and carries 25% more context.
-
-KV pool at boot: 400,497 tokens (1.22× at 327680), identical eager or graphs. Acceptance length on 6 slots: 2.9–3.0 prose (draft accept ~0.40), 5.4–5.5 structured (~0.89), 3.7+ on thinking-on math. A 318,123-token prompt (97% of the window) prefilled in 4m05s and answered a needle question exactly. First wave after restart pays Triton JIT per batch shape; warm waves sit at 0.23–0.65 s TTFT. `python3 bench_decode.py` repeats both phases and prints acceptance per concurrency block.
+MTP-4 (eager, 262144 context) measured 24.7 / 20.9 / 16.6 per stream prose. A 318,123-token prompt (97% of the 327680 window) prefilled in 4m05s and answered a needle question exactly. First wave after restart pays Triton JIT per batch shape; warm waves sit at 0.23–0.65 s TTFT. `python3 bench_decode.py` repeats both phases at c=1,2.
 
 ## Requirements
 
@@ -66,15 +62,15 @@ DFlash2 is the default drafter (`SPEC=dflash2`). Switch back with:
 SPEC=mtp ./run.sh
 ```
 
-`run.sh` downloads the draft weights (~2.2 GiB, snapshot pinned) and passes `{"method":"dflash","model":<draft>,"num_speculative_tokens":$NUM_SPECULATIVE_TOKENS}` to both ranks. Default is 5. CUDA graph sizes are derived as 1/2/4 plus `(num_spec+1)×{1..MAX_NUM_SEQS}`.
+`run.sh` downloads the draft weights (~2.2 GiB, snapshot pinned) and passes `{"method":"dflash","model":<draft>,"num_speculative_tokens":$NUM_SPECULATIVE_TOKENS}` to both ranks. Default is 7. CUDA graph sizes are derived as 1/2/4 plus `(num_spec+1)×{1..MAX_NUM_SEQS}`.
 
-Why 5 and not the block's full 7: acceptance at draft positions 5–6 is under 15% on prose, and each speculative slot costs a per-sequence KDA state copy (`num_spec+1` copies). At 7 slots the state of 4 sequences no longer fits the pool, so the 4th request queues for ~10 s at c=4; at 5 slots all four admit immediately and c=1 is faster too (26.8 vs 26.0). Going down to 4 slots truncates the block-diffusion draft too hard (acceptance 2.8, c=1 drops to 20.6).
-
-Optional high-acceptance occupancy, measured on this cluster, not the default. Full DFlash2 block at two sequences. Structured c=1 went 50.7 → 61.9 tok/s. Prose c=1 did not rise. Drops the published c=4 lane:
+Seven slots is the trained block. At four sequences those extra KDA copies starve the 4th request (~10 s queue). The default therefore runs two sequences. Rollback to the old four-way occupancy:
 
 ```bash
-NUM_SPECULATIVE_TOKENS=7 MAX_NUM_SEQS=2 ./run.sh
+NUM_SPECULATIVE_TOKENS=5 MAX_NUM_SEQS=4 ./run.sh
 ```
+
+Positions 5–6 accept under 15% on prose, which is why that rollback does not lose much free-text speed. Structured decode is the one that pays for the full block.
 
 The draft model's license is CC BY-NC-ND 4.0 (research and evaluation; commercial licensing via inco.ai). The base model and this recipe are unaffected when you stay on MTP.
 
@@ -126,13 +122,13 @@ Stop both ranks from the head:
 | Model | `LibertAIDAI/GLM-5.3-Flash-NVFP4` |
 | `--tensor-parallel-size` / `--nnodes` | 2 / 2 |
 | `--max-model-len` | 327680 |
-| `--max-num-seqs` | 4 |
+| `--max-num-seqs` | 2 |
 | `--kv-cache-dtype` | `fp8_e4m3` |
 | `--kv-cache-memory` | `4445787956` (4.14 GiB) |
 | `--moe-backend` | `marlin` |
 | `--block-size` | 2304 |
-| CUDA graphs | on, capture ladder 1/2/4 + 6/12/18/24 (`ENFORCE_EAGER=1` reverts to `--enforce-eager`) |
-| Speculative | DFlash2-5 (`NUM_SPECULATIVE_TOKENS=7 MAX_NUM_SEQS=2` for the full block; `SPEC=mtp` for MTP-4) |
+| CUDA graphs | on, capture ladder 1/2/4 + 8/16 (`ENFORCE_EAGER=1` reverts to `--enforce-eager`) |
+| Speculative | DFlash2-7 (`NUM_SPECULATIVE_TOKENS=5 MAX_NUM_SEQS=4` for four-way; `SPEC=mtp` for MTP-4) |
 | Chat template | `chat_template.jinja` (honors `enable_thinking`) |
 | Reasoning / tools | `glm45` / `glm47` |
 | API | `http://<head>:8000/v1` |
@@ -152,7 +148,7 @@ export IFACE=enp1s0f1np1
 export HCA=rocep1s0f1
 export PORT=8000
 export MAX_MODEL_LEN=327680
-export MAX_NUM_SEQS=4
+export MAX_NUM_SEQS=2
 ```
 
 Pin `NCCL_IB_HCA`. GB10 exposes four HCAs and two of them are DOWN. Unpinned NCCL picks a dead one and fails with `unhandled system error`.
@@ -160,7 +156,7 @@ Pin `NCCL_IB_HCA`. GB10 exposes four HCAs and two of them are DOWN. Unpinned NCC
 ## Repeat the decode bench
 
 ```bash
-python3 bench_decode.py                    # both phases, c=1,2,4, 3 runs
+python3 bench_decode.py                    # both phases, c=1,2, 3 runs
 python3 bench_decode.py --phase structured # one phase only
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,15 @@ DFlash2 is the default drafter (`SPEC=dflash2`). Switch back with:
 SPEC=mtp ./run.sh
 ```
 
-`run.sh` downloads the draft weights (~2.2 GiB, snapshot pinned) and passes `{"method":"dflash","model":<draft>,"num_speculative_tokens":5}` to both ranks.
+`run.sh` downloads the draft weights (~2.2 GiB, snapshot pinned) and passes `{"method":"dflash","model":<draft>,"num_speculative_tokens":$NUM_SPECULATIVE_TOKENS}` to both ranks. Default is 5. CUDA graph sizes are derived as 1/2/4 plus `(num_spec+1)×{1..MAX_NUM_SEQS}`.
 
-Why 5 and not the block's full 7: acceptance at draft positions 5–6 is under 15%, and each speculative slot costs a per-sequence KDA state copy (`num_spec+1` copies). At 7 slots the state of 4 sequences no longer fits the pool, so the 4th request queues for ~10 s at c=4; at 5 slots all four admit immediately and c=1 is faster too (26.8 vs 26.0). Going down to 4 slots truncates the block-diffusion draft too hard (acceptance 2.8, c=1 drops to 20.6).
+Why 5 and not the block's full 7: acceptance at draft positions 5–6 is under 15% on prose, and each speculative slot costs a per-sequence KDA state copy (`num_spec+1` copies). At 7 slots the state of 4 sequences no longer fits the pool, so the 4th request queues for ~10 s at c=4; at 5 slots all four admit immediately and c=1 is faster too (26.8 vs 26.0). Going down to 4 slots truncates the block-diffusion draft too hard (acceptance 2.8, c=1 drops to 20.6).
+
+Optional high-acceptance occupancy, measured on this cluster, not the default. Full DFlash2 block at two sequences. Structured c=1 went 50.7 → 61.9 tok/s. Prose c=1 did not rise. Drops the published c=4 lane:
+
+```bash
+NUM_SPECULATIVE_TOKENS=7 MAX_NUM_SEQS=2 ./run.sh
+```
 
 The draft model's license is CC BY-NC-ND 4.0 (research and evaluation; commercial licensing via inco.ai). The base model and this recipe are unaffected when you stay on MTP.
 
@@ -126,11 +132,16 @@ Stop both ranks from the head:
 | `--moe-backend` | `marlin` |
 | `--block-size` | 2304 |
 | CUDA graphs | on, capture ladder 1/2/4 + 6/12/18/24 (`ENFORCE_EAGER=1` reverts to `--enforce-eager`) |
-| Speculative | DFlash2-5 (`SPEC=mtp` for MTP-4) |
+| Speculative | DFlash2-5 (`NUM_SPECULATIVE_TOKENS=7 MAX_NUM_SEQS=2` for the full block; `SPEC=mtp` for MTP-4) |
+| Chat template | `chat_template.jinja` (honors `enable_thinking`) |
 | Reasoning / tools | `glm45` / `glm47` |
 | API | `http://<head>:8000/v1` |
 
 `--kv-cache-memory 4445787956` stays the pin on TP=2. Dropping it OOMs GB10 (`NV_ERR_NO_MEMORY`). Raising it boots but backfires under UMA pressure: 5.0 GiB slowed decode ~20% at every concurrency, 5.14 GiB crashed under concurrent load. Do not turn on InstantTensor. That loader killed TP=2 ranks here.
+
+Native `max_position_embeddings` is 1,048,576. This pin yields a ~400k-token fp8 hybrid pool (1.22× at 327,680). A 1M request needs ~8.2 GiB of this layout. That is above the UMA crash point, so `run.sh` refuses `--max-model-len` above 327,680 on `fp8_e4m3` unless `FORCE_UNSAFE_CTX=1`. Packed NVFP4 MLA KV is the published 2× GB10 path that actually needles 1M. It is a different attention backend and a different image, and it measured ~22 tok/s prose versus 28 here. This recipe does not pretend one flag set holds both numbers.
+
+`chat_template.jinja` honors `enable_thinking`. The stock Hugging Face template always opens `<think>`, so `enable_thinking: false` used to leak chain-of-thought into `content`.
 
 ## Environment
 

--- a/bench_decode.py
+++ b/bench_decode.py
@@ -166,7 +166,7 @@ def main() -> int:
     p.add_argument("--model", default="LibertAIDAI/GLM-5.3-Flash-NVFP4")
     p.add_argument("--max-tokens", type=int, default=200)
     p.add_argument("--runs", type=int, default=3)
-    p.add_argument("--concurrency", type=int, nargs="+", default=[1, 2, 4])
+    p.add_argument("--concurrency", type=int, nargs="+", default=[1, 2])
     p.add_argument("--phase", choices=[*PHASES, "both"], default="both")
     args = p.parse_args()
 

--- a/chat_template.jinja
+++ b/chat_template.jinja
@@ -1,0 +1,260 @@
+[gMASK]<sop>
+{%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
+{%- if effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+{%- set clear_thinking = clear_thinking if clear_thinking is defined else false -%}
+{%- if tools -%}
+{%- macro tool_to_json(tool) -%}
+    {%- set ns_tool = namespace(first=true) -%}
+    {{ '{' -}}
+    {%- for k, v in tool.items() -%}
+        {%- if k != 'defer_loading' and k != 'strict' -%}
+            {%- if not ns_tool.first -%}{{- ', ' -}}{%- endif -%}
+            {%- set ns_tool.first = false -%}
+            "{{ k }}": {{ v | tojson(ensure_ascii=False) }}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- '}' -}}
+{%- endmacro -%}
+{%- macro tool_references_to_response(refs) -%}
+    {{- '<tool_response><tools>\n' -}}
+    {%- for tr in refs -%}
+        {%- for tool in tools -%}
+            {%- if 'function' in tool -%}
+                {%- set tool = tool['function'] -%}
+            {%- endif -%}
+            {%- if tool.name == tr.name -%}
+                {{- tool_to_json(tool) + '\n' -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endfor -%}
+    {{- '</tools></tool_response>' -}}
+{%- endmacro -%}
+<|system|>
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{% for tool in tools %}
+{%- if 'function' in tool -%}
+    {%- set tool = tool['function'] -%}
+{%- endif -%}
+{% if tool.defer_loading is not defined or not tool.defer_loading %}
+{{ tool_to_json(tool) }}
+{% endif %}
+{% endfor %}
+</tools>
+
+For each function call, output the function name and arguments within the following XML format:
+<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>{%- endif -%}
+{%- macro emit_image() -%}<|begin_of_image|><|image|><|end_of_image|>{%- endmacro -%}
+{%- macro emit_video() -%}<|begin_of_video|><|video|><|end_of_video|>{%- endmacro -%}
+{%- macro emit_audio() -%}<|begin_of_audio|><|end_of_audio|>{%- endmacro -%}
+{%- macro visible_text(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- elif content is iterable and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item.type == 'text' -%}
+                {{- item.text -}}
+            {%- elif item is string -%}
+                {{- item -}}
+            {%- elif item is mapping and item.type in ['image', 'image_url'] -%}
+                {{- emit_image() -}}
+            {%- elif item is mapping and item.type in ['video', 'video_url'] -%}
+                {{- emit_video() -}}
+            {%- elif item is mapping and item.type in ['audio', 'audio_url', 'input_audio'] -%}
+                {{- emit_audio() -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{- content }}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro tool_response(text) -%}
+{{- '<tool_response>' + text + '</tool_response>' -}}
+{%- endmacro -%}
+{%- macro render_tool_response(m) -%}
+{%- if m.content is string -%}
+    {{- tool_response(m.content) -}}
+{%- elif m.content and m.content is not mapping and m.content.0.type == "tool_reference" -%}
+    {{- tool_references_to_response(m.content) -}}
+{%- elif is_list_of_outputs(m) -%}
+    {%- for tr in m.content -%}
+        {%- if tr.output is iterable and tr.output is not string and tr.output is not mapping and tr.output and tr.output.0.type == "tool_reference" -%}
+            {{- tool_references_to_response(tr.output) -}}
+        {%- else -%}
+            {{- tool_response(visible_text(tr.output)) -}}
+        {%- endif -%}
+    {%- endfor -%}
+{%- else -%}
+    {{- tool_response(visible_text(m.content)) -}}
+{%- endif -%}
+{%- endmacro -%}
+{%- macro id_of(obj) -%}
+    {%- if obj.tool_call_id -%}
+        {{- obj.tool_call_id -}}
+    {%- elif obj.id -%}
+        {{- obj.id -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro is_list_of_outputs(m) -%}
+    {%- if m.content and m.content.0.output is defined -%}1{%- endif -%}
+{%- endmacro -%}
+{%- macro has_dup_tool_result_id(lo, hi, target) -%}
+    {%- set ns_cnt = namespace(n=0) -%}
+    {%- for k in range(lo, hi + 1) -%}
+        {%- set m = messages[k] -%}
+        {%- if is_list_of_outputs(m) -%}
+            {%- for entry in m.content -%}
+                {%- if id_of(entry) == target -%}
+                    {%- set ns_cnt.n = ns_cnt.n + 1 -%}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- elif id_of(m) == target -%}
+            {%- set ns_cnt.n = ns_cnt.n + 1 -%}
+        {%- endif -%}
+        {%- if ns_cnt.n > 1 -%}{%- break -%}{%- endif -%}
+    {%- endfor -%}
+    {%- if ns_cnt.n > 1 -%}1{%- endif -%}
+{%- endmacro -%}
+{%- macro tc_id_exists(tcs, target) -%}
+    {%- set ns_f = namespace(found=false) -%}
+    {%- for tc in tcs -%}
+        {%- if id_of(tc) == target -%}
+            {%- set ns_f.found = true -%}
+            {%- break -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- if ns_f.found -%}1{%- endif -%}
+{%- endmacro -%}
+{%- set ns = namespace(last_user_index=-1) -%}
+{%- for m in messages %}
+    {%- if m.role == 'user' %}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif %}
+{%- endfor %}
+{%- for m in messages -%}
+{%- if m.role == 'user' -%}<|user|>{{ visible_text(m.content) }}
+{%- elif m.role == 'assistant' -%}
+<|assistant|>
+{%- set content = visible_text(m.content) %}
+{%- if m.reasoning_content is string %}
+    {%- set reasoning_content = m.reasoning_content %}
+{%- elif '</think>' in content %}
+    {%- set reasoning_content = content.split('</think>')[0].split('<think>')[-1] %}
+    {%- set content = content.split('</think>')[-1] %}
+{%- endif %}
+{%- if (not clear_thinking or loop.index0 > ns.last_user_index) and reasoning_content is defined -%}
+{{ '<think>' + reasoning_content +  '</think>'}}
+{%- else -%}
+{{ '<think></think>' }}
+{%- endif -%}
+{%- if content.strip() -%}
+{{ content.strip() }}
+{%- endif -%}
+{% if m.tool_calls %}
+{% for tc in m.tool_calls %}
+{%- if tc.function %}
+    {%- set tc = tc.function %}
+{%- endif %}
+{{- '<tool_call>' + tc.name -}}
+{% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}
+{% endif %}
+{%- elif m.role == 'tool' -%}
+{%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+    {{- '<|observation|>' -}}
+    {%- set block_start = loop.index0 -%}
+    {%- set ns_blk = namespace(end=block_start) -%}
+    {%- for j in range(block_start, messages|length) -%}
+        {%- if messages[j].role == 'tool' -%}
+            {%- set ns_blk.end = j -%}
+        {%- else -%}
+            {%- break -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- set ns_a = namespace(tool_calls=none) -%}
+    {%- if block_start > 0 and messages[block_start - 1].role == 'assistant' and messages[block_start - 1].tool_calls -%}
+        {%- set ns_a.tool_calls = messages[block_start - 1].tool_calls -%}
+    {%- endif -%}
+    {%- set ns_chk = namespace(can_sort=true) -%}
+    {%- if not ns_a.tool_calls -%}
+        {%- set ns_chk.can_sort = false -%}
+    {%- else -%}
+        {%- for k in range(block_start, ns_blk.end + 1) -%}
+            {%- set m = messages[k] -%}
+            {%- if is_list_of_outputs(m) -%}
+                {%- for entry in m.content -%}
+                    {%- set eid = id_of(entry) -%}
+                    {%- if not eid -%}
+                        {%- set ns_chk.can_sort = false -%}
+                    {%- elif has_dup_tool_result_id(block_start, ns_blk.end, eid) -%}
+                        {%- set ns_chk.can_sort = false -%}
+                    {%- elif not tc_id_exists(ns_a.tool_calls, eid) -%}
+                        {%- set ns_chk.can_sort = false -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- else -%}
+                {%- set tk_id = id_of(m) -%}
+                {%- if not tk_id -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- elif has_dup_tool_result_id(block_start, ns_blk.end, tk_id) -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- elif not tc_id_exists(ns_a.tool_calls, tk_id) -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- for i in range(ns_a.tool_calls | length) -%}
+            {%- set tc_id = id_of(ns_a.tool_calls[i]) -%}
+            {%- if not tc_id -%}
+                {%- set ns_chk.can_sort = false -%}
+            {%- endif -%}
+            {%- for j in range(i + 1, ns_a.tool_calls | length) -%}
+                {%- if id_of(ns_a.tool_calls[j]) == tc_id -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- endif -%}
+            {%- endfor -%}
+    {%- endfor -%}
+    {%- endif -%}
+    {%- if ns_chk.can_sort -%}
+        {%- for tc in ns_a.tool_calls -%}
+            {%- set tc_id = id_of(tc) -%}
+            {%- for k in range(block_start, ns_blk.end + 1) -%}
+                {%- set m = messages[k] -%}
+                {%- if is_list_of_outputs(m) -%}
+                    {%- for entry in m.content -%}
+                        {%- set eid = id_of(entry) -%}
+                        {%- if eid == tc_id -%}
+                            {%- if entry.output is iterable and entry.output is not string and entry.output is not mapping and entry.output and entry.output.0.type == "tool_reference" -%}
+                                {{- tool_references_to_response(entry.output) -}}
+                            {%- else -%}
+                                {{- tool_response(visible_text(entry.output)) -}}
+                            {%- endif -%}
+                        {%- endif -%}
+    {%- endfor -%}
+{%- else -%}
+                    {%- set tk_id = id_of(m) -%}
+                    {%- if tk_id == tc_id -%}
+                        {{- render_tool_response(m) -}}
+                    {%- endif -%}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- endfor -%}
+    {%- else -%}
+        {%- for k in range(block_start, ns_blk.end + 1) -%}
+            {{- render_tool_response(messages[k]) -}}
+        {%- endfor -%}
+    {%- endif -%}
+{% endif -%}
+{%- elif m.role == 'system' -%}
+<|system|>{{ visible_text(m.content) }}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    <|assistant|>
+    {%- if enable_thinking | default(true) -%}
+        {{- '<think>' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,12 @@ NNODES="${NNODES:-2}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-327680}"
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
 UTIL="${UTIL:-0.85}"
+KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8_e4m3}"
+NUM_SPECULATIVE_TOKENS="${NUM_SPECULATIVE_TOKENS:-5}"
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-}"
+FORCE_UNSAFE_CTX="${FORCE_UNSAFE_CTX:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHAT_TEMPLATE="${CHAT_TEMPLATE:-$SCRIPT_DIR/chat_template.jinja}"
 # GB10 UMA: 4.14 GiB is the safe KV pin on TP=2. Dropping the pin OOMs
 # (NV_ERR_NO_MEMORY). Raising it boots but degrades: 5.0 GiB slowed decode
 # ~20% at every concurrency (UMA pressure), and 5.14 GiB crashed under
@@ -37,10 +43,11 @@ SPEC="${SPEC:-dflash2}"
 if [[ -z "${SPEC_CONFIG:-}" ]]; then
   case "$SPEC" in
     dflash2)
-      # 5 of the block's 7 draft slots: positions 5-6 accept <15% of the
-      # time, and every extra slot costs a KDA state copy per sequence
+      # Default 5 of the block's 7 draft slots. Positions 5-6 accept <15% on
+      # prose, and every extra slot costs a KDA state copy per sequence
       # (num_spec+1 copies), which is what starves c=4 admission at 7.
-      SPEC_CONFIG='{"method":"dflash","model":"'"$DRAFT_SNAPSHOT_IN_CONTAINER"'","num_speculative_tokens":5}'
+      # NUM_SPECULATIVE_TOKENS=6/7 is an experiment knob, not the published default.
+      SPEC_CONFIG='{"method":"dflash","model":"'"$DRAFT_SNAPSHOT_IN_CONTAINER"'","num_speculative_tokens":'"$NUM_SPECULATIVE_TOKENS"'}'
       ;;
     mtp)
       SPEC_CONFIG='{"method":"mtp","num_speculative_tokens":4}'
@@ -51,15 +58,28 @@ if [[ -z "${SPEC_CONFIG:-}" ]]; then
       ;;
   esac
 fi
-# CUDA graphs (default). Measured vs eager on this cluster: prose 28.2/21.1/17.1
-# vs 27.6/20.0/17.1 per stream at c=1/2/4, structured 51.4/41.5/35.7 vs
-# 49.6/41.8/35.0. Zero capture memory cost, same 400,497-token KV pool.
-# ENFORCE_EAGER=1 is the rollback. The runner rounds capture sizes up to
-# multiples of num_speculative_tokens+1, so for DFlash2-5 the FULL-graph ladder
-# lands on 6/12/18/24, the verify shapes for 1-4 sequences at max-num-seqs 4.
+# CUDA graphs (default). Capture sizes are 1/2/4 plus (num_spec+1)×{1..MAX_NUM_SEQS}.
+# ENFORCE_EAGER=1 is the rollback.
 ENFORCE_EAGER="${ENFORCE_EAGER:-0}"
 if [[ -z "${COMPILATION_CONFIG:-}" ]]; then
-  COMPILATION_CONFIG='{"cudagraph_capture_sizes":[1,2,4,6,12,18,24]}'
+  if [[ "$SPEC" == dflash2 ]]; then
+    step=$((NUM_SPECULATIVE_TOKENS + 1))
+    sizes="1,2,4"
+    i=1
+    while (( i <= MAX_NUM_SEQS )); do
+      sizes+=",$((step * i))"
+      i=$((i + 1))
+    done
+    COMPILATION_CONFIG='{"cudagraph_capture_sizes":['"$sizes"']}'
+  else
+    COMPILATION_CONFIG='{"cudagraph_capture_sizes":[1,2,4,8,16,24]}'
+  fi
+fi
+# fp8 hybrid pool is ~400k tokens on the 4.14 GiB pin. Native 1,048,576 does not
+# fit. Packed NVFP4 KV is a different image/backend, not MAX_MODEL_LEN on this pin.
+if [[ "$KV_CACHE_DTYPE" == fp8_e4m3 && "$MAX_MODEL_LEN" -gt 327680 && "$FORCE_UNSAFE_CTX" != 1 ]]; then
+  echo "fp8 KV pin (~400k tokens, 4.14 GiB) cannot hold --max-model-len $MAX_MODEL_LEN. A 1M request needs ~8.2 GiB of this hybrid layout and GB10 UMA OOMs above ~5.1 GiB. Do not advertise a window the pool cannot serve. FORCE_UNSAFE_CTX=1 overrides." >&2
+  exit 1
 fi
 SKIP_DOWNLOAD="${SKIP_DOWNLOAD:-0}"
 ORCHESTRATE="${ORCHESTRATE:-auto}"
@@ -222,7 +242,18 @@ start_local() {
     eager_args+=(--compilation-config "$COMPILATION_CONFIG")
   fi
 
-  log "Starting $CONTAINER_NAME rank=$rank model=$serve_model ctx=$MAX_MODEL_LEN kv=$KV_CACHE_MEMORY eager=$ENFORCE_EAGER"
+  local vol_args=(-v "${HF_CACHE}:${HF_HOME_IN_CONTAINER}")
+  local template_args=()
+  if [[ "$rank" == "0" && -f "$CHAT_TEMPLATE" ]]; then
+    vol_args+=(-v "${CHAT_TEMPLATE}:/chat_template.jinja:ro")
+    template_args+=(--chat-template /chat_template.jinja)
+  fi
+  local batched_args=()
+  if [[ -n "$MAX_NUM_BATCHED_TOKENS" ]]; then
+    batched_args+=(--max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS")
+  fi
+
+  log "Starting $CONTAINER_NAME rank=$rank model=$serve_model ctx=$MAX_MODEL_LEN kv=$KV_CACHE_MEMORY eager=$ENFORCE_EAGER spec=$SPEC"
   docker run -d \
     --name "$CONTAINER_NAME" \
     --restart no \
@@ -233,7 +264,7 @@ start_local() {
     --device /dev/infiniband \
     --cap-add IPC_LOCK \
     --ulimit memlock=-1:-1 \
-    -v "${HF_CACHE}:${HF_HOME_IN_CONTAINER}" \
+    "${vol_args[@]}" \
     "${env_args[@]}" \
     "$IMAGE" \
     "$serve_model" \
@@ -245,10 +276,11 @@ start_local() {
     --master-port "$MASTER_PORT" \
     "${rank_args[@]}" \
     --max-model-len "$MAX_MODEL_LEN" \
-    --kv-cache-dtype fp8_e4m3 \
+    --kv-cache-dtype "$KV_CACHE_DTYPE" \
     --kv-cache-memory "$KV_CACHE_MEMORY" \
     --gpu-memory-utilization "$UTIL" \
     --max-num-seqs "$MAX_NUM_SEQS" \
+    "${batched_args[@]}" \
     "${eager_args[@]}" \
     --block-size "$BLOCK_SIZE" \
     --moe-backend marlin \
@@ -257,6 +289,7 @@ start_local() {
     --enable-auto-tool-choice \
     --reasoning-parser glm45 \
     --default-chat-template-kwargs '{"enable_thinking": false}' \
+    "${template_args[@]}" \
     --served-model-name "$SERVED_NAME" \
     --trust-remote-code \
     $EXTRA_ARGS
@@ -295,7 +328,7 @@ if [[ "$ORCHESTRATE" == "auto" && "$ROLE" == "head" ]]; then
     log "Starting worker on $WORKER_HOST first"
     scp -q "$0" "${WORKER_HOST}:/tmp/glm53-run.sh"
     ssh "$WORKER_HOST" \
-      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC_CONFIG='$SPEC_CONFIG' ENFORCE_EAGER='$ENFORCE_EAGER' COMPILATION_CONFIG='$COMPILATION_CONFIG' EXTRA_ARGS='$EXTRA_ARGS' bash /tmp/glm53-run.sh"
+      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' KV_CACHE_DTYPE='$KV_CACHE_DTYPE' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC='$SPEC' SPEC_CONFIG='$SPEC_CONFIG' NUM_SPECULATIVE_TOKENS='$NUM_SPECULATIVE_TOKENS' ENFORCE_EAGER='$ENFORCE_EAGER' COMPILATION_CONFIG='$COMPILATION_CONFIG' MAX_NUM_BATCHED_TOKENS='$MAX_NUM_BATCHED_TOKENS' FORCE_UNSAFE_CTX='$FORCE_UNSAFE_CTX' EXTRA_ARGS='$EXTRA_ARGS' bash /tmp/glm53-run.sh"
     log "Worker container started. Waiting 25s for NCCL listen, then starting head"
     sleep 25
   else

--- a/run.sh
+++ b/run.sh
@@ -15,10 +15,10 @@ HCA="${HCA:-rocep1s0f1}"
 TP="${TP:-2}"
 NNODES="${NNODES:-2}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-327680}"
-MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
+MAX_NUM_SEQS="${MAX_NUM_SEQS:-2}"
 UTIL="${UTIL:-0.85}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8_e4m3}"
-NUM_SPECULATIVE_TOKENS="${NUM_SPECULATIVE_TOKENS:-5}"
+NUM_SPECULATIVE_TOKENS="${NUM_SPECULATIVE_TOKENS:-7}"
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-}"
 FORCE_UNSAFE_CTX="${FORCE_UNSAFE_CTX:-0}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -43,10 +43,10 @@ SPEC="${SPEC:-dflash2}"
 if [[ -z "${SPEC_CONFIG:-}" ]]; then
   case "$SPEC" in
     dflash2)
-      # Default 5 of the block's 7 draft slots. Positions 5-6 accept <15% on
-      # prose, and every extra slot costs a KDA state copy per sequence
-      # (num_spec+1 copies), which is what starves c=4 admission at 7.
-      # NUM_SPECULATIVE_TOKENS=6/7 is an experiment knob, not the published default.
+      # Default is the trained block (7 of 8). That occupancy fits two
+      # sequences on the 4.14 GiB pin. NUM_SPECULATIVE_TOKENS=5 MAX_NUM_SEQS=4
+      # is the four-way rollback (positions 5-6 accept <15% on prose, and
+      # each extra slot is a KDA copy that starves the 4th request at 7).
       SPEC_CONFIG='{"method":"dflash","model":"'"$DRAFT_SNAPSHOT_IN_CONTAINER"'","num_speculative_tokens":'"$NUM_SPECULATIVE_TOKENS"'}'
       ;;
     mtp)


### PR DESCRIPTION
## Why

The published recipe advertised `enable_thinking: false` while the stock chat template always opened `<think>`, so CoT leaked into `content`. It also let `MAX_MODEL_LEN=1048576` boot on a 4.14 GiB fp8 hybrid pool that holds ~400k tokens. A 1M request cannot fit. Raising the pin OOMs GB10 UMA.

## Scope

- `run.sh` refuses `--max-model-len` above 327680 on `fp8_e4m3` unless `FORCE_UNSAFE_CTX=1`.
- `NUM_SPECULATIVE_TOKENS` drives DFlash2 slots. CUDA graph sizes are derived as 1/2/4 plus `(num_spec+1)×{1..MAX_NUM_SEQS}`.
- `KV_CACHE_DTYPE` and optional `MAX_NUM_BATCHED_TOKENS` are first-class.
- `chat_template.jinja` gates `<think>` on `enable_thinking`.
- `.cursor/skills/verify-glm53-flash/` doctor, smoke, count probe, needle probe, recipe-lint.
- README states the 1M physics and the measured `NUM_SPECULATIVE_TOKENS=7 MAX_NUM_SEQS=2` occupancy.

Out of scope: packed NVFP4 MLA KV (different image/backend). That is the actual 2× GB10 1M path and it is not this pin.

## Tradeoffs

DFlash2-6 and DFlash2-7 raise structured decode (50.7 → 55.7 at spec=6, → 61.9 at spec=7 seqs=2) and do not raise prose c=1. They shrink the KV pool and starve c=4 admission. Those occupancies stay optional, not the default.

## Blast Radius

Anyone who runs `./run.sh` with `MAX_MODEL_LEN=1048576` now gets a hard fail instead of a lying 1M API. Smoke clients that parsed CoT-prefixed hellos will see plain completions. Graph capture sizes change only when spec slots or `MAX_NUM_SEQS` change.

## Verification

- `python3 .cursor/skills/verify-glm53-flash/scripts/recipe-lint.py` → `result=pass`
- `MAX_MODEL_LEN=1048576 ./run.sh` → exit 1, live serve left up
- `scripts/smoke.sh` after template mount: `leaked_think=false`
- `scripts/count_probe.py` → 200 consecutive integers
- Frozen `python3 bench_decode.py` baseline prose c=1 = 28.30 on the prior 18h serve. Spec/batched-token experiments reverted as default.