### PR TITLE
feat: add optional verified ABLIT o_proj transplant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .DS_Store
 __pycache__/
 *.pyc
+/ablit/transplant/
 
 .audit/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Serve [LibertAIDAI/GLM-5.3-Flash-NVFP4](https://huggingface.co/LibertAIDAI/GLM-5
 
 320B total / 18B active. Weight-only NVFP4 on routed experts (~181 GiB). Native context is 1,048,576. This recipe serves `--max-model-len` 327680 with the DFlash2 block-diffusion drafter (7 speculative tokens, two sequences).
 
-Stock `vllm/vllm-openai:glm53-flash-arm64-cu130` loads on sm_121 and echoes the prompt. Build the local image chain through `glm53-sm121-v11` first.
+Stock `vllm/vllm-openai:glm53-flash-arm64-cu130` loads on sm_121 and echoes the prompt. Build the local image chain through `glm53-sm121-v12` first.
 
 ## Measured on 2× DGX Spark (L.A.I.L lab)
 
@@ -42,6 +42,7 @@ docker build -f docker/Dockerfile.sm121-v8 -t glm53-sm121-v8 docker
 docker build -f docker/Dockerfile.sm121-v9 -t glm53-sm121-v9 docker
 docker build -f docker/Dockerfile.sm121-v10 -t glm53-sm121-v10 docker
 docker build -f docker/Dockerfile.sm121-v11 -t glm53-sm121-v11 docker
+docker build -f docker/Dockerfile.sm121-v12 -t glm53-sm121-v12 docker
 ```
 
 The v8 Dockerfile starts from `vllm/vllm-openai:glm53-flash-arm64-cu130` and applies the sm_121 patches (NoPE FA2 backend, FlashInfer 0.6.18, NCCL 2.30.7, PDL off, indexer init, fp8 tile cap). `run.sh` refuses the stock tag.
@@ -51,6 +52,8 @@ The next three layers are all required for `SPEC=dflash2` (MTP works on v8):
 - v9 backports DFlash2 support, vLLM PR [#52816](https://github.com/vllm-project/vllm/pull/52816), missing from the image's vLLM snapshot.
 - v10 teaches the fork-only Glm5Next model to capture aux hidden states for the drafter (the mHC stream contraction follows the reference integration, sglang [#36708](https://github.com/sgl-project/sglang/pull/36708)).
 - v11 adds a dedicated draft KV group to the GLM5 bespoke KV layout so the draft's sliding-window layers share the pool.
+
+The v12 layer installs the optional ABLIT load hook. It is inert by default, so `ABLIT=0` leaves the loaded weights unchanged from v11.
 
 ## DFlash2 drafter
 
@@ -73,6 +76,28 @@ NUM_SPECULATIVE_TOKENS=5 MAX_NUM_SEQS=4 ./run.sh
 Positions 5–6 accept under 15% on prose, which is why that rollback does not lose much free-text speed. Structured decode is the one that pays for the full block.
 
 The draft model's license is CC BY-NC-ND 4.0 (research and evaluation; commercial licensing via inco.ai). The base model and this recipe are unaffected when you stay on MTP.
+
+## Optional ABLIT transplant
+
+`ABLIT=1` replaces only the unquantized BF16 attention `o_proj` weights in layers 15–44 after the stock NVFP4 checkpoint loads. Native MTP also replaces layer 45; the external DFlash2 drafter is not modified. Checkpoint files remain untouched.
+
+Fetch the published donor tensors once on the head, then copy them to the same path on the worker:
+
+```bash
+export ABLIT_DIR="$HOME/.cache/huggingface/glm53-ablit"
+python3 ablit/fetch_transplant.py
+rsync -a --info=progress2 "$ABLIT_DIR/" spark2:"$ABLIT_DIR/"
+```
+
+Enable the transplant on the next container start:
+
+```bash
+ABLIT=1 ./run.sh
+```
+
+The launcher verifies all 31 files against the donor manifest before stopping either running rank. The runtime verifies each tensor again as it is loaded. Missing, incompatible, or corrupt tensors fail closed. `ABLIT=0` remains the stock path.
+
+The fetcher and load-hook design are adapted from [MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks) under its MIT license. The ~2.7 GB transplant comes from [dealignai/GLM-5.3-Flash-UNCENSORED-NVFP4](https://huggingface.co/dealignai/GLM-5.3-Flash-UNCENSORED-NVFP4); its model license applies.
 
 ## Quick start
 
@@ -118,7 +143,7 @@ Stop both ranks from the head:
 
 | Setting | Value |
 |---|---|
-| Image | `glm53-sm121-v11` (local) |
+| Image | `glm53-sm121-v12` (local; ABLIT hook off by default) |
 | Model | `LibertAIDAI/GLM-5.3-Flash-NVFP4` |
 | `--tensor-parallel-size` / `--nnodes` | 2 / 2 |
 | `--max-model-len` | 327680 |
@@ -149,6 +174,7 @@ export HCA=rocep1s0f1
 export PORT=8000
 export MAX_MODEL_LEN=327680
 export MAX_NUM_SEQS=2
+export ABLIT=0 # set 1 to enable the verified donor transplant on restart
 ```
 
 Pin `NCCL_IB_HCA`. GB10 exposes four HCAs and two of them are DOWN. Unpinned NCCL picks a dead one and fails with `unhandled system error`.

--- a/ablit/fetch_transplant.py
+++ b/ablit/fetch_transplant.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fetch the published GLM-5.3 abliterated o_proj tensors for layers 15–45.
+
+Downloads only the tensor byte ranges (~2.7 GB), not the full donor checkpoint.
+Adapted from MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks at b5ab809.
+Copyright (c) 2026 Mia's AI Lab, used under the MIT license in ../LICENSE.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = Path(os.environ.get("ABLIT_DIR", REPO_ROOT / "ablit")) / "transplant"
+DONOR = os.environ.get("ABLIT_DONOR", "dealignai/GLM-5.3-Flash-UNCENSORED-NVFP4")
+REVISION = os.environ.get("ABLIT_DONOR_REVISION", "main")
+LAYERS = range(15, 46)
+CHUNK = 8 * 1024 * 1024
+RETRIES = 4
+
+TOKEN = os.environ.get("HF_TOKEN", "")
+if not TOKEN:
+    token_file = Path.home() / ".cache/huggingface/token"
+    if token_file.is_file():
+        TOKEN = token_file.read_text().strip()
+
+
+def auth() -> dict[str, str]:
+    return {"Authorization": f"Bearer {TOKEN}"} if TOKEN else {}
+
+
+def http(url: str, start: int | None = None, end: int | None = None):
+    request = urllib.request.Request(url, headers=auth())
+    if start is not None:
+        request.add_header("Range", f"bytes={start}-{end if end is not None else ''}")
+    return urllib.request.urlopen(request, timeout=120)
+
+
+def fetch_bytes(url: str, start: int, end: int, label: str) -> bytes:
+    """Fetch one inclusive byte range, resuming short reads in memory."""
+    expected = end - start + 1
+    output = bytearray()
+    failures = 0
+    while len(output) < expected:
+        try:
+            with http(url, start + len(output), end) as response:
+                if response.status != 206:
+                    raise RuntimeError(f"expected HTTP 206, got {response.status}")
+                before = len(output)
+                while chunk := response.read(min(CHUNK, expected - len(output))):
+                    output.extend(chunk)
+                if len(output) == before:
+                    raise RuntimeError(f"short read at {len(output)}/{expected}")
+            failures = 0
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            if failures >= RETRIES:
+                raise SystemExit(f"failed to fetch {label}: {exc}") from exc
+            wait = failures * 3
+            print(
+                f"  retry {failures}/{RETRIES} for {label} at "
+                f"{len(output)}/{expected} ({exc}); sleeping {wait}s",
+                flush=True,
+            )
+            time.sleep(wait)
+    return bytes(output)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(CHUNK):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def tensor_span(shard_url: str, key: str) -> tuple[int, int, dict]:
+    header_size = int.from_bytes(fetch_bytes(shard_url, 0, 7, "safetensors header size"), "little")
+    header = json.loads(
+        fetch_bytes(shard_url, 8, 8 + header_size - 1, "safetensors header")
+    )
+    if key not in header:
+        raise SystemExit(f"{key} is missing from its mapped donor shard")
+    metadata = header[key]
+    start, end = metadata["data_offsets"]
+    return 8 + header_size + start, 8 + header_size + end - 1, metadata
+
+
+def get_json(url: str) -> dict:
+    with http(url) as response:
+        return json.load(response)
+
+
+def main() -> None:
+    encoded_donor = urllib.parse.quote(DONOR, safe="/")
+    encoded_revision = urllib.parse.quote(REVISION, safe="")
+    donor_sha = get_json(
+        f"https://huggingface.co/api/models/{encoded_donor}/revision/{encoded_revision}"
+    )["sha"]
+    base = f"https://huggingface.co/{encoded_donor}/resolve/{donor_sha}"
+    index = get_json(f"{base}/model.safetensors.index.json")["weight_map"]
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    manifest_path = OUT_DIR / "MANIFEST.json"
+    manifest = {
+        "donor": DONOR,
+        "donor_revision": REVISION,
+        "donor_sha": donor_sha,
+        "method": "dealign-oproj-transplant",
+        "layers": {},
+    }
+    if manifest_path.is_file():
+        previous = json.loads(manifest_path.read_text())
+        if previous.get("donor_sha") == donor_sha:
+            manifest = previous
+            print("resuming verified donor revision")
+
+    print(f"donor: {DONOR}@{donor_sha}")
+    for layer in LAYERS:
+        key = f"model.language_model.layers.{layer}.self_attn.o_proj.weight"
+        shard = index.get(key)
+        if shard is None:
+            raise SystemExit(f"donor index has no {key}")
+        path = OUT_DIR / f"L{layer}.bin"
+        metadata = {int(key): value for key, value in manifest["layers"].items()}
+        if (
+            path.is_file()
+            and layer in metadata
+            and path.stat().st_size == int(metadata[layer]["nbytes"])
+            and file_sha256(path) == metadata[layer]["sha256"]
+        ):
+            print(f"L{layer}: already fetched ({path.stat().st_size / 1e6:.0f} MB)")
+            continue
+
+        shard_url = f"{base}/{shard}"
+        start, end, tensor = tensor_span(shard_url, key)
+        size = end - start + 1
+        print(f"L{layer}: {tensor['dtype']} {tensor['shape']} ({size / 1e6:.0f} MB)")
+        data = fetch_bytes(shard_url, start, end, f"layer {layer}")
+        temporary = path.with_suffix(".tmp")
+        temporary.write_bytes(data)
+        temporary.replace(path)
+        manifest["layers"][str(layer)] = {
+            "shard": shard,
+            "key": key,
+            "dtype": tensor["dtype"],
+            "shape": tensor["shape"],
+            "nbytes": size,
+            "sha256": hashlib.sha256(data).hexdigest(),
+        }
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    total = sum(int(item["nbytes"]) for item in manifest["layers"].values())
+    print(f"done: {len(manifest['layers'])}/31 tensors, {total / 1e9:.2f} GB -> {OUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/Dockerfile.sm121-v12
+++ b/docker/Dockerfile.sm121-v12
@@ -1,0 +1,13 @@
+FROM glm53-sm121-v11
+
+# Optional, in-memory o_proj transplant. ABLIT=0 leaves loaded weights unchanged;
+# ABLIT=1 reads verified donor tensors from /opt/glm53/ablit.
+COPY ablit_runtime.py patch_v12_ablit.py test_v12_ablit.py /opt/glm53/
+RUN cd /opt/glm53 \
+    && python3 test_v12_ablit.py \
+    && python3 patch_v12_ablit.py \
+    && python3 -m compileall -q \
+        /usr/local/lib/python3.12/dist-packages/vllm/models/glm5next/nvidia/model.py \
+        /usr/local/lib/python3.12/dist-packages/vllm/models/glm5next/nvidia/mtp.py \
+        /usr/local/lib/python3.12/dist-packages/vllm/models/glm5next/nvidia/glm53_ablit.py \
+    && rm test_v12_ablit.py patch_v12_ablit.py

--- a/docker/ablit_runtime.py
+++ b/docker/ablit_runtime.py
@@ -1,0 +1,152 @@
+"""Optional load-time GLM-5.3 o_proj transplant.
+
+The launcher exposes one switch: ABLIT=1. Donor tensors are full BF16 weights;
+each TP rank copies its input-dimension shard after the stock checkpoint loads.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import torch
+
+try:
+    from vllm.logger import init_logger
+
+    logger = init_logger(__name__)
+except Exception:
+    logger = logging.getLogger("glm53_ablit")
+
+_LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.self_attn\.o_proj$")
+_MTP_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.mtp_block\.self_attn\.o_proj$")
+
+
+class AblitError(RuntimeError):
+    """The explicitly enabled transplant could not be applied safely."""
+
+
+def _flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value in ("0", "false", "no", "off"):
+        return False
+    raise AblitError(f"{name} must be 0 or 1, got {value!r}")
+
+
+def _tp_world() -> int:
+    try:
+        from vllm.distributed import get_tensor_model_parallel_world_size
+
+        return get_tensor_model_parallel_world_size()
+    except Exception:
+        return 1
+
+
+def _tp_rank() -> int:
+    try:
+        from vllm.distributed import get_tensor_model_parallel_rank
+
+        return get_tensor_model_parallel_rank()
+    except Exception:
+        return 0
+
+
+def _layers(spec: str) -> set[int]:
+    result: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo, hi = map(int, part.split("-", 1))
+            if lo > hi:
+                raise AblitError(f"inverted ABLIT_LAYERS range: {part}")
+            result.update(range(lo, hi + 1))
+        else:
+            result.add(int(part))
+    if not result:
+        raise AblitError("ABLIT_LAYERS is empty")
+    return result
+
+
+def _text_model(model: Any) -> Any:
+    language_model = getattr(model, "language_model", None)
+    if language_model is None:
+        return model
+    return getattr(language_model, "model", language_model)
+
+
+def maybe_apply(model: Any) -> dict[str, Any] | None:
+    """Apply the configured transplant, or do nothing when ABLIT is disabled."""
+    if not _flag("ABLIT"):
+        return None
+
+    root = Path(os.environ.get("ABLIT_DIR", "/opt/glm53/ablit")) / "transplant"
+    manifest_path = root / "MANIFEST.json"
+    if not manifest_path.is_file():
+        raise AblitError(f"missing donor manifest: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text())
+    metadata = {
+        int(layer): info
+        for layer, info in (manifest.get("layers") or manifest.get("tensors") or {}).items()
+    }
+    wanted = _layers(os.environ.get("ABLIT_LAYERS", "15-45"))
+    world, rank = _tp_world(), _tp_rank()
+    if world < 1 or rank not in range(world):
+        raise AblitError(f"invalid tensor-parallel rank {rank}/{world}")
+    edited: list[int] = []
+
+    for name, module in _text_model(model).named_modules():
+        match = _MTP_RE.search(name)
+        if match is None:
+            match = _LAYER_RE.search(name)
+        if match is None:
+            continue
+
+        layer = int(match.group(1))
+        if layer not in wanted:
+            continue
+        info = metadata.get(layer)
+        if info is None:
+            raise AblitError(f"donor manifest has no layer {layer}")
+        if info.get("dtype") != "BF16":
+            raise AblitError(f"donor layer {layer} is not BF16")
+
+        path = root / f"L{layer}.bin"
+        if not path.is_file():
+            raise AblitError(f"donor layer {layer} is missing: {path}")
+        raw = bytearray(path.read_bytes())
+        if len(raw) != int(info["nbytes"]):
+            raise AblitError(f"donor layer {layer} size mismatch")
+        if hashlib.sha256(raw).hexdigest() != info.get("sha256"):
+            raise AblitError(f"donor layer {layer} sha256 mismatch")
+        donor = torch.frombuffer(raw, dtype=torch.bfloat16).reshape(tuple(info["shape"]))
+        weight = getattr(module, "weight", None)
+        if weight is None or weight.ndim != 2:
+            raise AblitError(f"{name} has no 2-D weight")
+
+        local_in = weight.shape[1]
+        if donor.shape[0] != weight.shape[0] or donor.shape[1] != local_in * world:
+            raise AblitError(
+                f"{name} shape {tuple(weight.shape)} does not match donor "
+                f"{tuple(donor.shape)} at TP={world}"
+            )
+        donor = donor[:, rank * local_in : (rank + 1) * local_in]
+        with torch.no_grad():
+            weight.copy_(donor.to(device=weight.device, dtype=weight.dtype))
+        edited.append(layer)
+
+    if not edited:
+        raise AblitError("ABLIT=1 matched no o_proj weights")
+    logger.info("ablit: transplanted donor o_proj layers=%s TP=%d rank=%d", edited, world, rank)
+    return {"edited_layers": edited, "tp_world": world, "tp_rank": rank}

--- a/docker/patch_v12_ablit.py
+++ b/docker/patch_v12_ablit.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Install the ABLIT load-time hook into the glm53-flash vLLM image (idempotent).
+
+Copies ablit_runtime.py next to the glm5next model files and appends a hook
+call at the end of Glm5NextModel.load_weights (target layers 0-44) and
+Glm5NextMTP.load_weights (checkpoint MTP block, layer 45). The hook no-ops
+unless ABLIT=1, so installing it is inert on stock serves.
+
+Runs once while building the v12 image.
+
+Adapted from MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks at b5ab809.
+Copyright (c) 2026 Mia's AI Lab, used under the MIT license in ../LICENSE.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+SITE = Path("/usr/local/lib/python3.12/dist-packages/vllm")
+NVIDIA_DIR = SITE / "models/glm5next/nvidia"
+MODEL_PY = NVIDIA_DIR / "model.py"
+MTP_PY = NVIDIA_DIR / "mtp.py"
+RUNTIME_SRC = Path("/opt/glm53/ablit_runtime.py")
+RUNTIME_DST = NVIDIA_DIR / "glm53_ablit.py"
+
+MARKER = "ABLIT-HOOK"
+HOOK_LINES = (
+    "        from vllm.models.glm5next.nvidia.glm53_ablit import maybe_apply "
+    "as _glm53_ablit_maybe_apply  # ABLIT-HOOK\n"
+    "        _glm53_ablit_maybe_apply(self)  # ABLIT-HOOK\n"
+)
+
+MODEL_TAIL = """                    weight_loader(param, loaded_weight, **kwargs)
+            loaded_params.add(name)
+        return loaded_params"""
+
+MTP_TAIL = """                    f"missing from checkpoint."
+                )
+        return loaded_params"""
+
+
+def replace_once(path: Path, old: str, new: str, label: str) -> None:
+    text = path.read_text()
+    if MARKER in text:
+        print(f"{path.name}: {MARKER} already present — skipping")
+        return
+    n = text.count(old)
+    if n != 1:
+        raise SystemExit(f"{path}: expected one patch target, found {n}: {old!r}")
+    path.write_text(text.replace(old, new))
+    print(f"patched {path.name} ({label})")
+
+
+def main() -> None:
+    NVIDIA_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(RUNTIME_SRC, RUNTIME_DST)
+    print(f"installed {RUNTIME_DST}")
+
+    replace_once(
+        MODEL_PY,
+        MODEL_TAIL,
+        MODEL_TAIL.replace(
+            "        return loaded_params", HOOK_LINES + "        return loaded_params"
+        ),
+        "Glm5NextModel.load_weights",
+    )
+
+    replace_once(
+        MTP_PY,
+        MTP_TAIL,
+        MTP_TAIL.replace(
+            "        return loaded_params", HOOK_LINES + "        return loaded_params"
+        ),
+        "Glm5NextMTP.load_weights",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/test_v12_ablit.py
+++ b/docker/test_v12_ablit.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Small build-time check for the optional transplant and TP sharding."""
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import torch
+from torch import nn
+
+import ablit_runtime
+
+
+class Attention(nn.Module):
+    def __init__(self, input_features):
+        super().__init__()
+        self.o_proj = nn.Linear(input_features, 4, bias=False, dtype=torch.bfloat16)
+
+
+class Layer(nn.Module):
+    def __init__(self, input_features):
+        super().__init__()
+        self.self_attn = Attention(input_features)
+
+
+class Model(nn.Module):
+    def __init__(self, input_features):
+        super().__init__()
+        self.layers = nn.ModuleList([Layer(input_features), Layer(input_features)])
+
+
+def write_donor(root, donor):
+    raw = donor.view(torch.uint8).numpy().tobytes()
+    transplant = Path(root) / "transplant"
+    transplant.mkdir()
+    (transplant / "L1.bin").write_bytes(raw)
+    (transplant / "MANIFEST.json").write_text(
+        json.dumps(
+            {
+                "layers": {
+                    "1": {
+                        "dtype": "BF16",
+                        "shape": list(donor.shape),
+                        "nbytes": len(raw),
+                        "sha256": hashlib.sha256(raw).hexdigest(),
+                    }
+                }
+            }
+        )
+    )
+
+
+donor = torch.arange(16, dtype=torch.float32).reshape(4, 4).to(torch.bfloat16)
+with tempfile.TemporaryDirectory() as root:
+    write_donor(root, donor)
+    os.environ.update(ABLIT="1", ABLIT_DIR=root, ABLIT_LAYERS="1")
+
+    model = Model(4)
+    report = ablit_runtime.maybe_apply(model)
+    assert report["edited_layers"] == [1]
+    assert torch.equal(model.layers[1].self_attn.o_proj.weight, donor)
+
+with tempfile.TemporaryDirectory() as root:
+    write_donor(root, donor)
+    os.environ.update(ABLIT="1", ABLIT_DIR=root, ABLIT_LAYERS="1")
+    ablit_runtime._tp_world = lambda: 2
+    ablit_runtime._tp_rank = lambda: 1
+
+    model = Model(2)
+    report = ablit_runtime.maybe_apply(model)
+    assert report["tp_rank"] == 1
+    assert torch.equal(model.layers[1].self_attn.o_proj.weight, donor[:, 2:])
+
+os.environ["ABLIT"] = "0"
+assert ablit_runtime.maybe_apply(Model(4)) is None
+
+print("v12 ablit runtime self-check passed")

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 MODEL="${MODEL:-LibertAIDAI/GLM-5.3-Flash-NVFP4}"
 SERVED_NAME="${SERVED_NAME:-LibertAIDAI/GLM-5.3-Flash-NVFP4}"
-IMAGE="${IMAGE:-glm53-sm121-v11}"
+IMAGE="${IMAGE:-glm53-sm121-v12}"
 CONTAINER_NAME="${CONTAINER_NAME:-glm53-flash-nvfp4}"
 PORT="${PORT:-8000}"
 MASTER_PORT="${MASTER_PORT:-29521}"
@@ -32,13 +32,18 @@ KV_CACHE_MEMORY="${KV_CACHE_MEMORY:-4445787956}"
 BLOCK_SIZE="${BLOCK_SIZE:-2304}"
 HF_CACHE="${HF_CACHE:-$HOME/.cache/huggingface}"
 HF_HOME_IN_CONTAINER="/cache/huggingface"
+# Optional verified load-time o_proj transplant; inert unless ABLIT=1.
+ABLIT="${ABLIT:-0}"
+ABLIT_DIR="${ABLIT_DIR:-$HF_CACHE/glm53-ablit}"
+ABLIT_LAYERS="${ABLIT_LAYERS:-15-45}"
+ABLIT_VERIFIED=0
 SNAPSHOT="${HF_CACHE}/hub/models--LibertAIDAI--GLM-5.3-Flash-NVFP4/snapshots/aa28e1f54130286c95fee10d0705c74ce8743734"
 SNAPSHOT_IN_CONTAINER="${HF_HOME_IN_CONTAINER}/hub/models--LibertAIDAI--GLM-5.3-Flash-NVFP4/snapshots/aa28e1f54130286c95fee10d0705c74ce8743734"
 DRAFT_MODEL="${DRAFT_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
 DRAFT_SNAPSHOT="${HF_CACHE}/hub/models--incoai--GLM-5.3-Flash-DFlash2/snapshots/7d74cdd881ed7e32c31175984a67823127b66cfe"
 DRAFT_SNAPSHOT_IN_CONTAINER="${HF_HOME_IN_CONTAINER}/hub/models--incoai--GLM-5.3-Flash-DFlash2/snapshots/7d74cdd881ed7e32c31175984a67823127b66cfe"
 # SPEC picks the drafter: dflash2 (incoai DFlash2 block-diffusion draft, needs
-# the glm53-sm121-v11 image) or mtp (GLM's native MTP head).
+# the glm53-sm121-v11+ image) or mtp (GLM's native MTP head).
 SPEC="${SPEC:-dflash2}"
 if [[ -z "${SPEC_CONFIG:-}" ]]; then
   case "$SPEC" in
@@ -139,7 +144,7 @@ maybe_drop_caches() {
 ensure_image() {
   log "Ensuring image $IMAGE"
   if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-    echo "Image $IMAGE not found. Build the local image chain through glm53-sm121-v11 first (see README). Do not use stock vllm/vllm-openai on sm_121." >&2
+    echo "Image $IMAGE not found. Build the local image chain through glm53-sm121-v12 first (see README). Do not use stock vllm/vllm-openai on sm_121." >&2
     exit 1
   fi
 }
@@ -176,6 +181,54 @@ ensure_weights() {
   fi
 }
 
+ensure_ablit() {
+  case "$ABLIT" in
+    0) return ;;
+    1) ;;
+    *) echo "ABLIT must be 0 or 1, got: $ABLIT" >&2; exit 1 ;;
+  esac
+  if [[ "$ABLIT_VERIFIED" == 1 ]]; then
+    return
+  fi
+  log "Verifying ABLIT donor tensors under $ABLIT_DIR"
+  python3 - "$ABLIT_DIR" "$ABLIT_LAYERS" <<'PY'
+import hashlib, json, sys
+from pathlib import Path
+
+root = Path(sys.argv[1]) / "transplant"
+wanted = set()
+for part in sys.argv[2].split(","):
+    part = part.strip()
+    if "-" in part:
+        lo, hi = map(int, part.split("-", 1))
+        if lo > hi:
+            raise SystemExit(f"inverted ABLIT_LAYERS range: {part}")
+        wanted.update(range(lo, hi + 1))
+    elif part:
+        wanted.add(int(part))
+if not wanted:
+    raise SystemExit("ABLIT_LAYERS is empty")
+manifest_path = root / "MANIFEST.json"
+if not manifest_path.is_file():
+    raise SystemExit(f"missing {manifest_path}; run ablit/fetch_transplant.py")
+manifest = json.loads(manifest_path.read_text())
+metadata = {int(k): v for k, v in manifest.get("layers", {}).items()}
+for layer in sorted(wanted):
+    info = metadata.get(layer)
+    path = root / f"L{layer}.bin"
+    if info is None or not path.is_file():
+        raise SystemExit(f"missing donor layer {layer} under {root}")
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    if path.stat().st_size != int(info["nbytes"]) or digest.hexdigest() != info["sha256"]:
+        raise SystemExit(f"donor layer {layer} failed size/sha256 verification")
+print(f"verified {len(wanted)} donor tensors")
+PY
+  ABLIT_VERIFIED=1
+}
+
 stop_local() {
   if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
     log "Removing existing container $CONTAINER_NAME"
@@ -190,9 +243,10 @@ start_local() {
     echo "docker not found" >&2
     exit 1
   fi
+  ensure_image
+  ensure_ablit
   maybe_drop_caches
   stop_local
-  ensure_image
   ensure_weights
 
   local serve_model
@@ -243,6 +297,14 @@ start_local() {
   fi
 
   local vol_args=(-v "${HF_CACHE}:${HF_HOME_IN_CONTAINER}")
+  if [[ "$ABLIT" == 1 ]]; then
+    vol_args+=(-v "${ABLIT_DIR}:/opt/glm53/ablit:ro")
+    env_args+=(
+      -e "ABLIT=1"
+      -e "ABLIT_DIR=/opt/glm53/ablit"
+      -e "ABLIT_LAYERS=$ABLIT_LAYERS"
+    )
+  fi
   local template_args=()
   if [[ "$rank" == "0" && -f "$CHAT_TEMPLATE" ]]; then
     vol_args+=(-v "${CHAT_TEMPLATE}:/chat_template.jinja:ro")
@@ -253,7 +315,7 @@ start_local() {
     batched_args+=(--max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS")
   fi
 
-  log "Starting $CONTAINER_NAME rank=$rank model=$serve_model ctx=$MAX_MODEL_LEN kv=$KV_CACHE_MEMORY eager=$ENFORCE_EAGER spec=$SPEC"
+  log "Starting $CONTAINER_NAME rank=$rank model=$serve_model ctx=$MAX_MODEL_LEN kv=$KV_CACHE_MEMORY eager=$ENFORCE_EAGER spec=$SPEC ablit=$ABLIT"
   docker run -d \
     --name "$CONTAINER_NAME" \
     --restart no \
@@ -324,11 +386,13 @@ ROLE="$(detect_role)"
 log "role=$ROLE host=$(host_short)"
 
 if [[ "$ORCHESTRATE" == "auto" && "$ROLE" == "head" ]]; then
+  ensure_image
+  ensure_ablit
   if command -v ssh >/dev/null 2>&1 && ssh -o BatchMode=yes -o ConnectTimeout=5 "$WORKER_HOST" true >/dev/null 2>&1; then
     log "Starting worker on $WORKER_HOST first"
     scp -q "$0" "${WORKER_HOST}:/tmp/glm53-run.sh"
     ssh "$WORKER_HOST" \
-      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' KV_CACHE_DTYPE='$KV_CACHE_DTYPE' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC='$SPEC' SPEC_CONFIG='$SPEC_CONFIG' NUM_SPECULATIVE_TOKENS='$NUM_SPECULATIVE_TOKENS' ENFORCE_EAGER='$ENFORCE_EAGER' COMPILATION_CONFIG='$COMPILATION_CONFIG' MAX_NUM_BATCHED_TOKENS='$MAX_NUM_BATCHED_TOKENS' FORCE_UNSAFE_CTX='$FORCE_UNSAFE_CTX' EXTRA_ARGS='$EXTRA_ARGS' bash /tmp/glm53-run.sh"
+      "ROLE=worker ORCHESTRATE=0 IMAGE='$IMAGE' CONTAINER_NAME='$CONTAINER_NAME' PORT='$PORT' MASTER_PORT='$MASTER_PORT' HEAD_IP='$HEAD_IP' IFACE='$IFACE' HCA='$HCA' MAX_MODEL_LEN='$MAX_MODEL_LEN' MAX_NUM_SEQS='$MAX_NUM_SEQS' UTIL='$UTIL' KV_CACHE_MEMORY='$KV_CACHE_MEMORY' KV_CACHE_DTYPE='$KV_CACHE_DTYPE' BLOCK_SIZE='$BLOCK_SIZE' TP='$TP' NNODES='$NNODES' SERVED_NAME='$SERVED_NAME' SKIP_DOWNLOAD='$SKIP_DOWNLOAD' SPEC='$SPEC' SPEC_CONFIG='$SPEC_CONFIG' NUM_SPECULATIVE_TOKENS='$NUM_SPECULATIVE_TOKENS' ENFORCE_EAGER='$ENFORCE_EAGER' COMPILATION_CONFIG='$COMPILATION_CONFIG' MAX_NUM_BATCHED_TOKENS='$MAX_NUM_BATCHED_TOKENS' FORCE_UNSAFE_CTX='$FORCE_UNSAFE_CTX' ABLIT='$ABLIT' ABLIT_DIR='$ABLIT_DIR' ABLIT_LAYERS='$ABLIT_LAYERS' EXTRA_ARGS='$EXTRA_ARGS' bash /tmp/glm53-run.sh"
     log "Worker container started. Waiting 25s for NCCL listen, then starting head"
     sleep 25
   else


### PR DESCRIPTION
## Summary

- add a minimal `glm53-sm121-v12` layer that installs an inert load-time hook on top of v11
- enable the published GLM-5.3 `o_proj` transplant with one flag: `ABLIT=1`
- fetch only layers 15–45 from the donor via resumable safetensors range requests (~2.7 GB rather than the full checkpoint)
- verify donor size/SHA256 on both hosts before replacing a healthy container, then verify SHA256, dtype, shape, and TP slicing again while loading
- keep checkpoint files and the external DFlash2 drafter untouched

`ABLIT=0` is the default and leaves the loaded weights unchanged. With DFlash2, the target model receives layers 15–44. Native MTP also receives layer 45.

The fetcher resolves `main` to an immutable Hugging Face commit and records it in the manifest. The design is adapted from MiaAI-Lab's EXL3 recipe under MIT; attribution and donor licensing are documented.

## Validation

- `bash -n run.sh`
- `shellcheck run.sh`
- Python compile checks for the fetcher, runtime, patcher, and self-check
- donor API/index/safetensors-header resolution against `dealignai/GLM-5.3-Flash-UNCENSORED-NVFP4@e90ef415a2bf1274f848965a61144eca1e99eabf`
- clean Docker build from local `glm53-sm121-v11`; build-time TP=1/TP=2 transplant self-check passed
- patch anchors matched both `Glm5NextModel.load_weights` and `Glm5NextMTP.load_weights`, followed by `compileall`
- live prototype validated on 2× GB10 TP=2: both ranks logged transplanted layers 15–44 and an OpenAI chat smoke test completed successfully

No model weights are committed or baked into the image.
