### PR TITLE
feat(recipe): recipe.yaml as source of truth with render-check

### DIFF
--- a/.github/workflows/render-check.yml
+++ b/.github/workflows/render-check.yml
@@ -1,0 +1,17 @@
+name: render-check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  render-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: pip install pyyaml
+      - run: python3 kit/render.py --check

--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ Stock `vllm/vllm-openai:glm53-flash-arm64-cu130` loads on sm_121 and echoes the 
 
 Decode only. Streamed greedy, thinking off, 200 completion tokens, 3-run median. `max-num-seqs=2`, fp8 KV pinned at 4.14 GiB, context 327680, DFlash2-7, CUDA graphs. Prose is the low-acceptance regime (free text); structured (count 1→200, same protocol as the EXL3 recipe) is the high-acceptance regime.
 
+<!-- BEGIN generated measured from recipe.yaml — edit recipe.yaml and run kit/render.py -->
 | Phase | Concurrency | Decode tok/s (median per stream) | Aggregate tok/s | TTFT p50 |
 |---|---|---:|---:|---:|
 | prose | 1 | 19.7 | 19.7 | 0.34 s |
 | prose | 2 | 16.3 | 31.0 | 0.36 s |
 | structured | 1 | 67.1 | 67.1 | 0.34 s |
 | structured | 2 | 59.9 | 119.7 | 0.37 s |
+<!-- END generated measured -->
 
 Default occupancy is the trained DFlash2 block (7 draft slots) at two sequences. Structured is the occupancy ruler (50.7 → 68.1 at c=1 versus DFlash2-5 / four sequences). Prose now stops near the requested eighty words (~105 tokens) once thinking-off seeds `<think></think>`, so it is no longer a 200-token pad. `MAX_NUM_SEQS=3` at DFlash2-7 does not starve the third stream, but structured c=2 fell 59.5 → 50.7. Four-way admission needs the rollback `NUM_SPECULATIVE_TOKENS=5 MAX_NUM_SEQS=4`. CUDA graphs capture 1/2/4 plus 8/16 (verify shapes for 1–2 sequences). `ENFORCE_EAGER=1` is the rollback; it slowed structured c=1 68.1 → 65.0. Adding capture size 3 to the ladder was inside noise. Capture size 24 at two sequences was unused and stayed inside noise. `VLLM_USE_BREAKABLE_CUDAGRAPH=0` slowed structured c=2 59.7 → 52.1. Leave the engine auto-on. `--async-scheduling` boots with DFlash2-7 and keeps FULL_AND_PIECEWISE graphs. Versus this table every cell stayed inside noise. Versus the restore before, prose c=2 fell 16.98 → 15.19. Leave it off. Greedy count stays lossless: 200 consecutive integers with thinking off. `MAX_NUM_BATCHED_TOKENS=4096` was measured at two sequences and reverted (structured c=2 55.5 → 51.6, KV pool 372877 → 363476). Tony's 3.0 GiB KV pin cannot boot `--max-model-len` 327680 (vLLM wants 3.62 GiB). The displayed 3.62 GiB pin (3886945403) still estimates max len 327168 and refuses. A 4.0 GiB pin boots but structured c=2 fell 59.5 → 52.4.
 
@@ -117,6 +119,7 @@ Stop both ranks from the head:
 
 ## Defaults
 
+<!-- BEGIN generated defaults from recipe.yaml — edit recipe.yaml and run kit/render.py -->
 | Setting | Value |
 |---|---|
 | Image | `glm53-sm121-v11` (local) |
@@ -134,6 +137,7 @@ Stop both ranks from the head:
 | Chat template | `chat_template.jinja` (honors `enable_thinking`) |
 | Reasoning / tools | `glm45` / `glm47` |
 | API | `http://<head>:8000/v1` |
+<!-- END generated defaults -->
 
 The 2026-08-30 LibertAI checkpoint ships real per-projection `input_scale` tensors. Marlin still never reads them. `flashinfer_cutlass` is not a path on 2× GB10. v11 dies at JIT (`nvrtc.h` missing). v12 with `cuda-nvrtc-dev-13-0` got past that and then global-OOM'd spark2 during `cudafe++` after 90.67 GiB weights (`NV_ERR_NO_MEMORY`, ~18 GiB left). `run.sh` refuses any `MOE_BACKEND` other than `marlin` unless `FORCE_UNSAFE_MOE=1`. Do not set `VLLM_GLM53_MOE_INPUT_SCALE=1.0`. That constant underflows per 16-element block. LibertAI's GB10 recipe ([glm53-flash-vllm-gb10](https://github.com/Libertai/glm53-flash-vllm-gb10)) is MTP-3, eager, 64K, about 24 tok/s. It is a different stack from this DFlash2-7 / graphs / 327680 bar.
 

--- a/kit/render.py
+++ b/kit/render.py
@@ -1,0 +1,152 @@
+# vendored from sfxnz/forge kit @ 3d294ff
+# Regenerate the marked blocks of run.sh and README.md from recipe.yaml.
+#
+#   python3 kit/render.py            rewrite the generated blocks in place
+#   python3 kit/render.py --check    exit 1 with a unified diff if any block is stale
+#   python3 kit/render.py --strict   also exit 1 when a measured row has no evidence file
+#
+# recipe.yaml is the source of truth. Nothing outside these markers is touched:
+#   run.sh     # BEGIN generated from recipe.yaml — edit recipe.yaml and run kit/render.py
+#              # END generated
+#   README.md  <!-- BEGIN generated defaults from recipe.yaml — edit recipe.yaml and run kit/render.py -->
+#              <!-- END generated defaults -->
+#              <!-- BEGIN generated measured from recipe.yaml — edit recipe.yaml and run kit/render.py -->
+#              <!-- END generated measured -->
+#
+# Inside the run.sh block every NAME="${NAME:-value}" line takes its value from serve.env; comment and
+# derived lines are kept verbatim. serve.env must list exactly those names, in run.sh order. README
+# defaults rows may use {NAME} placeholders for serve.env values. Needs python3 and PyYAML.
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+RUN_BEGIN = "# BEGIN generated from recipe.yaml — edit recipe.yaml and run kit/render.py"
+RUN_END = "# END generated"
+DEFAULT_LINE = re.compile(r'^([A-Z][A-Z0-9_]*)="\$\{\1:-.*\}"$')
+PLACEHOLDER = re.compile(r"\{([A-Z][A-Z0-9_]*)\}")
+DEFAULTS_HEADER = ["| Setting | Value |", "|---|---|"]
+MEASURED_HEADER = [
+    "| Phase | Concurrency | Decode tok/s (median per stream) | Aggregate tok/s | TTFT p50 |",
+    "|---|---|---:|---:|---:|",
+]
+NO_EVIDENCE = ("", "null", "~")  # BaseLoader keeps `null` as the string "null"
+
+
+def md_markers(name):
+    return (
+        f"<!-- BEGIN generated {name} from recipe.yaml — edit recipe.yaml and run kit/render.py -->",
+        f"<!-- END generated {name} -->",
+    )
+
+
+def find_block(lines, begin, end, path):
+    """Return (start, stop) so that lines[start:stop] is the body between the marker lines."""
+    starts = [i for i, line in enumerate(lines) if line == begin]
+    if len(starts) != 1:
+        sys.exit(f"render: {path}: need exactly one `{begin}` line, found {len(starts)}")
+    try:
+        stop = lines.index(end, starts[0] + 1)
+    except ValueError:
+        sys.exit(f"render: {path}: `{begin}` has no `{end}`")
+    return starts[0] + 1, stop
+
+
+def render_run_sh(text, env):
+    lines = text.split("\n")
+    start, stop = find_block(lines, RUN_BEGIN, RUN_END, "run.sh")
+    body, seen = [], []
+    for line in lines[start:stop]:
+        m = DEFAULT_LINE.match(line)
+        if not m:
+            body.append(line)
+            continue
+        name = m.group(1)
+        if name not in env:
+            sys.exit(f"render: run.sh sets {name} inside the generated block but serve.env has no {name}")
+        seen.append(name)
+        body.append(f'{name}="${{{name}:-{env[name]}}}"')
+    if seen != list(env):
+        sys.exit(
+            "render: serve.env must list the generated run.sh defaults in run.sh order\n"
+            f"  run.sh:      {' '.join(seen)}\n  recipe.yaml: {' '.join(env)}"
+        )
+    return "\n".join(lines[:start] + body + lines[stop:])
+
+
+def fill(template, env):
+    def value(m):
+        name = m.group(1)
+        if name not in env:
+            sys.exit(f"render: README row uses {{{name}}} but serve.env has no {name}")
+        return env[name]
+
+    return PLACEHOLDER.sub(value, template)
+
+
+def render_readme(text, recipe):
+    env = recipe["serve"]["env"]
+    lines = text.split("\n")
+    start, stop = find_block(lines, *md_markers("defaults"), "README.md")
+    rows = [f"| {fill(k, env)} | {fill(v, env)} |" for row in recipe["readme"]["defaults"] for k, v in row.items()]
+    lines[start:stop] = DEFAULTS_HEADER + rows
+    start, stop = find_block(lines, *md_markers("measured"), "README.md")
+    rows = [
+        f"| {r['phase']} | {r['concurrency']} | {r['decode']} | {r['aggregate']} | {r['ttft_p50']} s |"
+        for r in recipe["measured"]["decode"]["rows"]
+    ]
+    lines[start:stop] = MEASURED_HEADER + rows
+    return "\n".join(lines)
+
+
+def evidence_gaps(recipe, repo):
+    none, missing = [], []
+    for r in recipe["measured"]["decode"]["rows"]:
+        label = f"measured.decode {r['phase']} c={r['concurrency']}"
+        path = r.get("evidence", "")
+        if path in NO_EVIDENCE:
+            none.append(label)
+        elif not (repo / path).exists():
+            missing.append(f"{label}: {path}")
+    return none, missing
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Regenerate run.sh and README.md blocks from recipe.yaml.")
+    ap.add_argument("--check", action="store_true", help="print a diff and exit 1 instead of writing")
+    ap.add_argument("--strict", action="store_true", help="a row without an evidence file is an error")
+    args = ap.parse_args()
+    repo = Path(__file__).resolve().parent.parent
+    recipe = yaml.load((repo / "recipe.yaml").read_text(), Loader=yaml.BaseLoader)
+    renderers = {
+        "run.sh": lambda text: render_run_sh(text, recipe["serve"]["env"]),
+        "README.md": lambda text: render_readme(text, recipe),
+    }
+    stale = False
+    for name, render in renderers.items():
+        old = (repo / name).read_text()
+        new = render(old)
+        if new == old:
+            continue
+        if args.check:
+            sys.stdout.writelines(difflib.unified_diff(old.splitlines(True), new.splitlines(True), f"a/{name}", f"b/{name}"))
+            stale = True
+        else:
+            (repo / name).write_text(new)
+            print(f"render: wrote {name}")
+    none, missing = evidence_gaps(recipe, repo)
+    for label in none:
+        print(f"render: no evidence yet: {label}")
+    for label in missing:
+        print(f"render: WARNING evidence file missing: {label}")
+    if stale:
+        sys.exit("render: generated blocks are stale. Run: python3 kit/render.py")
+    if args.strict and (none or missing):
+        sys.exit("render: --strict: every measured row needs an existing evidence file")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,0 +1,98 @@
+# Source of truth for the values that repeat across run.sh, README.md and CI.
+# Edit here, then `python3 kit/render.py`. CI runs `python3 kit/render.py --check`.
+# Every scalar is used as the string you typed (0.80 stays 0.80). `null` means none.
+# `&name` anchors a value; `*name` reuses it, so a pinned value is written once.
+
+model:
+  id: &model LibertAIDAI/GLM-5.3-Flash-NVFP4
+  revision: &revision caca4e6a4ebbd66f159d3d2fc256683fd6e27177
+  served_name: &served_name LibertAIDAI/GLM-5.3-Flash-NVFP4
+  family: GLM-5.3-Flash
+  params: 320B total / 18B active
+  quant: NVFP4 (weight-only, routed experts)
+  draft: incoai/GLM-5.3-Flash-DFlash2 @ 7d74cdd881ed7e32c31175984a67823127b66cfe
+
+image:
+  base: vllm/vllm-openai:glm53-flash-arm64-cu130
+  digest: null
+  local_tag: &image glm53-sm121-v11
+  build: docker/Dockerfile.sm121-v8 -> v9 -> v10 -> v11
+
+engine:
+  name: vllm
+  version: null
+
+hardware:
+  shape: 2x DGX Spark (GB10)
+  nnodes: &nnodes 2
+  tp: &tp 2
+
+serve:
+  # The `# BEGIN generated` block of run.sh, in run.sh order. Each key renders as NAME="${NAME:-value}".
+  env:
+    MODEL: *model
+    SERVED_NAME: *served_name
+    IMAGE: *image
+    CONTAINER_NAME: glm53-flash-nvfp4
+    PORT: 8000
+    MASTER_PORT: 29521
+    HEAD_IP: 10.100.8.1
+    WORKER_HOST: spark2
+    IFACE: enp1s0f1np1
+    HCA: rocep1s0f1
+    TP: *tp
+    NNODES: *nnodes
+    MAX_MODEL_LEN: 327680
+    MAX_NUM_SEQS: 2
+    UTIL: 0.85
+    KV_CACHE_DTYPE: fp8_e4m3
+    NUM_SPECULATIVE_TOKENS: 7
+    MAX_NUM_BATCHED_TOKENS: ""
+    FORCE_UNSAFE_CTX: 0
+    FORCE_UNSAFE_MOE: 0
+    VLLM_USE_BREAKABLE_CUDAGRAPH: ""
+    CHAT_TEMPLATE: $SCRIPT_DIR/chat_template.jinja
+    KV_CACHE_MEMORY: 4445787956
+    BLOCK_SIZE: 2304
+    HF_CACHE: $HOME/.cache/huggingface
+    SNAPSHOT_REV: *revision
+    MOE_BACKEND: marlin
+    REASONING_PARSER: glm45
+    DRAFT_MODEL: incoai/GLM-5.3-Flash-DFlash2
+    SPEC: dflash2
+
+readme:
+  # Rows of the README "Defaults" table. {NAME} is replaced by serve.env.NAME.
+  defaults:
+    - Image: "`{IMAGE}` (local)"
+    - Model: "`{MODEL}`"
+    - "`--tensor-parallel-size` / `--nnodes`": "{TP} / {NNODES}"
+    - "`--max-model-len`": "{MAX_MODEL_LEN}"
+    - "`--max-num-seqs`": "{MAX_NUM_SEQS}"
+    - "`--kv-cache-dtype`": "`{KV_CACHE_DTYPE}`"
+    - "`--kv-cache-memory`": "`{KV_CACHE_MEMORY}` (4.14 GiB)"
+    - "`--moe-backend`": "`{MOE_BACKEND}` (`run.sh` refuses `flashinfer_cutlass`; it OOM'd spark2)"
+    - Checkpoint: "`{SNAPSHOT_REV}` (calibrated MoE `input_scale`; `SNAPSHOT_REV=aa28e1f54130286c95fee10d0705c74ce8743734` rolls back)"
+    - "`--block-size`": "{BLOCK_SIZE}"
+    - CUDA graphs: "on, capture ladder 1/2/4 + 8/16 (`ENFORCE_EAGER=1` reverts to `--enforce-eager`)"
+    - Speculative: "DFlash2-{NUM_SPECULATIVE_TOKENS} (`NUM_SPECULATIVE_TOKENS=5 MAX_NUM_SEQS=4` for four-way; `SPEC=mtp` for MTP-4)"
+    - Chat template: "`chat_template.jinja` (honors `enable_thinking`)"
+    - Reasoning / tools: "`{REASONING_PARSER}` / `glm47`"
+    - API: "`http://<head>:{PORT}/v1`"
+
+measured:
+  # The README decode table. One row per (phase, concurrency); a row's three numbers come from one
+  # bench_decode.py run. evidence: the file under evidence/ that contains them, or null while there is none.
+  decode:
+    conditions: streamed greedy, thinking off, 200 completion tokens, 3-run median; max-num-seqs=2, fp8 KV pinned at 4.14 GiB, context 327680, DFlash2-7, CUDA graphs
+    units: {decode: tok/s per stream (median), aggregate: tok/s, ttft_p50: s}
+    rows:
+      - {phase: prose, concurrency: 1, decode: 19.7, aggregate: 19.7, ttft_p50: 0.34, evidence: null}
+      - {phase: prose, concurrency: 2, decode: 16.3, aggregate: 31.0, ttft_p50: 0.36, evidence: null}
+      - {phase: structured, concurrency: 1, decode: 67.1, aggregate: 67.1, ttft_p50: 0.34, evidence: evidence/iter-h-snap/bench.txt}
+      - {phase: structured, concurrency: 2, decode: 59.9, aggregate: 119.7, ttft_p50: 0.37, evidence: null}
+
+links:
+  model: https://huggingface.co/LibertAIDAI/GLM-5.3-Flash-NVFP4
+  draft: https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2
+  repo: https://github.com/sfxnz/GLM-5.3-Flash-NVFP4-vLLM-2x-DGX-Spark

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,7 @@
 # GLM-5.3-Flash NVFP4 on 2x DGX Spark (GB10) — vLLM TP=2
 set -euo pipefail
 
+# BEGIN generated from recipe.yaml — edit recipe.yaml and run kit/render.py
 MODEL="${MODEL:-LibertAIDAI/GLM-5.3-Flash-NVFP4}"
 SERVED_NAME="${SERVED_NAME:-LibertAIDAI/GLM-5.3-Flash-NVFP4}"
 IMAGE="${IMAGE:-glm53-sm121-v11}"
@@ -52,6 +53,7 @@ DRAFT_SNAPSHOT_IN_CONTAINER="${HF_HOME_IN_CONTAINER}/hub/models--incoai--GLM-5.3
 # SPEC picks the drafter: dflash2 (incoai DFlash2 block-diffusion draft, needs
 # the glm53-sm121-v11 image) or mtp (GLM's native MTP head).
 SPEC="${SPEC:-dflash2}"
+# END generated
 if [[ -z "${SPEC_CONFIG:-}" ]]; then
   case "$SPEC" in
     dflash2)


### PR DESCRIPTION
## Summary

- `recipe.yaml` holds the values that repeat across `run.sh` and `README.md` (model, image, serve defaults, README defaults rows, measured decode rows with evidence paths).
- `kit/render.py` (vendored from `sfxnz/forge`, python3 + PyYAML) regenerates the marked blocks from it. `python3 kit/render.py --check` prints a unified diff and exits 1 when any block is stale.
- `.github/workflows/render-check.yml` runs `--check` on every PR and push to `main`.
- `run.sh` and `README.md` change by marker lines only (2 + 4 lines). The rendered blocks reproduce the current content byte for byte.

## Markers

- `run.sh`: `# BEGIN generated from recipe.yaml — edit recipe.yaml and run kit/render.py` … `# END generated` around the env-default block. Inside it every `NAME="${NAME:-value}"` line takes its value from `serve.env`; comments and derived lines are kept verbatim.
- `README.md`: `<!-- BEGIN generated defaults … -->` / `<!-- END generated defaults -->` around the Defaults table and `<!-- BEGIN generated measured … -->` / `<!-- END generated measured -->` around the decode table.

## How to change a value

```sh
edit recipe.yaml && python3 kit/render.py
```

## Evidence

Measured rows point at the file under `evidence/` that contains them. Three of the four decode rows (prose c=1, prose c=2, structured c=2) have no file that contains their numbers (`evidence/iter-h-snap/bench.txt` has 18.1 / 15.9 / 55.4), so they carry `evidence: null` and render prints them as `no evidence yet`. Structured c=1 points at `evidence/iter-h-snap/bench.txt`, which lands with #5; until then `--check` warns that the path is missing. `--strict` makes both an error and is meant to become the CI default once evidence is in.

## Relation to #5

Independent of #5 (`agent/phase0-evidence-ci`): separate workflow file, no shared hunks. Merge order does not matter.

## Test plan

- [x] `python3 kit/render.py --check` exits 0 with no diff
- [x] `git diff origin/main -- run.sh README.md` shows marker lines only
- [x] `VALIDATE_ONLY=1 ./run.sh` exits 0
- [x] `recipe-lint.py` prints `result=pass`
- [x] `shellcheck -S warning run.sh stop.sh` clean
- [x] a deliberate edit inside a generated block makes `--check` exit 1 with a diff; `python3 kit/render.py` restores it
- [x] CI simulation: `python3 -m venv /tmp/rc && /tmp/rc/bin/pip install pyyaml && /tmp/rc/bin/python kit/render.py --check`

Made with [Cursor](https://cursor.com)